### PR TITLE
Add packet per second (pps) metric

### DIFF
--- a/src/bpf_pflua_ts.lua
+++ b/src/bpf_pflua_ts.lua
@@ -40,7 +40,7 @@ function get_all_plans()
 end
 
 function prefix(p, s)
-   return s:sub(1,#p) == p 
+   return s:sub(1,#p) == p
 end
 
 function get_all_tests(p)
@@ -60,6 +60,9 @@ function get_all_tests(p)
       -- pcap_file
       elseif prefix("pcap_file:", line) then
          plan[current]['pcap_file'] = line:sub(#"pcap_file:"+1)
+      -- pcap_pkts
+      elseif prefix("pcap_pkts:", line) then
+         plan[current]['pcap_pkts'] = tonumber(line:sub(#"pcap_pkts:"+1))
       -- expected_result
       elseif prefix("expected_result:", line) then
          plan[current]['expected_result'] = tonumber(line:sub(#"expected_result:"+1))
@@ -107,6 +110,7 @@ function run_test_plan(p)
       print("description: " .. t['description'])
       print("filter: " .. t['filter'])
       print("pcap_file: " .. t['pcap_file'])
+      print("pcap_pkts: " .. t['pcap_pkts'])
       print("expected_result: " .. t['expected_result'])
       io.write("enabled: ")
       if t['enabled'] then
@@ -116,7 +120,12 @@ function run_test_plan(p)
          print("false")
          print("tc id " .. i .. " SKIP")
       end
-      print("tc id " .. i .. " AVG ET " .. elapsed_time)
+      print("tc id " .. i .. " ET " .. elapsed_time)
+      local pps = 0
+      if t['pcap_pkts'] ~= 0 then
+	 pps = t['pcap_pkts'] / elapsed_time
+      end
+      print("tc id " .. i .. " PPS " .. pps)
    end
 end
 

--- a/src/ts/tests/0001_plan.ts
+++ b/src/ts/tests/0001_plan.ts
@@ -20,6 +20,7 @@ id:1
 description:baseline
 filter:
 pcap_file:ws/v4.pcap
+pcap_pkts:43
 expected_result:43
 enabled:true
 
@@ -27,6 +28,7 @@ id:2
 description:ip
 filter:ip
 pcap_file:ws/v4.pcap
+pcap_pkts:43
 expected_result:43
 enabled:true
 
@@ -34,6 +36,7 @@ id:3
 description:tcp
 filter:tcp
 pcap_file:ws/v4.pcap
+pcap_pkts:43
 expected_result:41
 enabled:true
 
@@ -41,6 +44,7 @@ id:4
 description:tcp port
 filter:tcp port 80
 pcap_file:ws/v4.pcap
+pcap_pkts:43
 expected_result:41
 enabled:true
 
@@ -48,6 +52,7 @@ id:5
 description:tcp dst port
 filter:tcp dst port 23
 pcap_file:ws/telnet-cooked.pcap
+pcap_pkts:92
 expected_result:48
 enabled:true
 
@@ -55,6 +60,7 @@ id:6
 description:udp dst port
 filter:udp dst port 2087
 pcap_file:ws/tftp_wrq.pcap
+pcap_pkts:100
 expected_result:49
 enabled:true
 
@@ -62,6 +68,7 @@ id:7
 description:host check
 filter:host 192.168.0.13
 pcap_file:ws/tftp_wrq.pcap
+pcap_pkts:100
 expected_result:100
 enabled:true
 
@@ -69,6 +76,7 @@ id:8
 description:net mask test success
 filter:net 192.168.0.0 mask 255.255.255.0
 pcap_file:ws/telnet-cooked.pcap
+pcap_pkts:92
 expected_result:92
 enabled:true
 
@@ -76,6 +84,7 @@ id:9
 description:net mask test failure
 filter:net 192.168.50.0 mask 255.255.255.0
 pcap_file:ws/telnet-cooked.pcap
+pcap_pkts:92
 expected_result:0
 enabled:true
 
@@ -83,6 +92,7 @@ id:10
 description:no packets
 filter:icmp
 pcap_file:igalia/empty.pcap
+pcap_pkts:0
 expected_result:0
 enabled:true
 
@@ -90,5 +100,6 @@ id:11
 description:no packets
 filter:tcp port 80 and (((ip[2:2] - ((ip[0]&0xf)<<2)) - ((tcp[12]&0xf0)>>2)) != 0)
 pcap_file:igalia/empty.pcap
+pcap_pkts:0
 expected_result:0
 enabled:true


### PR DESCRIPTION
This patch adds pps (packets per second) metric. pps is the ratio of
number of total packets seen to elapsed time.

It is not possible calculating the number of total packets in a pcap
file with a simple iteration. Moreover, calculating this value adds
overhead in the function under testing. The suggested solution is adding
a new value in .ts files recording the value per pcap file. This value
goes under the key 'pcap_pkts'.
- bpf_pflua_ts.lua. calculates pps
- ts/tests/0001_plan.ts. pcap_pkts added
