### PR TITLE
Prints out generated asm for a pcap expression.

### DIFF
--- a/src/pf_pcap_asm
+++ b/src/pf_pcap_asm
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+PRINT=0
+
+filter="tcp port 80"
+if [ $# == 1 ]; then
+    filter=$1
+fi
+
+# Name of the script that prints out asm for a pred expression
+lua_script="pf_pcap_asm.lua"
+
+# Linenumber where the 'execute_pred_ensuring_trace' function is defined
+lineno=`grep -n 'function execute_pred_ensuring_trace' $lua_script | cut -d : -f 1`
+
+# Iterate through all asm output but print out only the fragment of asm code for the compiled pred expression
+output=`luajit -jdump=m -l pf_pcap_asm -e 'pf_pcap_asm.selftest()'`;
+while read -r line; do
+    # Was printing and found a blank line
+    if [ $PRINT -eq 1 ] && [ -z "$line" ]; then
+        break;
+    fi
+    # Is in printing mode
+    if [ $PRINT -eq 1 ]; then
+        echo "$line"
+        continue;
+    fi
+    # Found target TRACE, start printing
+    matches=$(echo $line | grep "$lua_script:$lineno")
+    if [ "$matches" ]; then
+        PRINT=1
+        echo "$line"
+    fi
+done <<< "$output"

--- a/src/pf_pcap_asm.lua
+++ b/src/pf_pcap_asm.lua
@@ -1,0 +1,74 @@
+--[[
+--
+-- This module is used to obtain the resulting jitted asm code for a pcap
+-- expression.
+--
+-- The file used for packet filtering is a 1GB file from pflua-bench, so it's
+-- necessary to clone that repo, uncompress the file and create a symbolic link:
+--
+--  $ git clone https://github.com/Igalia/pflua-bench.git
+--  $ pflua-bench=<path-to-pflua-bench>
+--  $ pflua=<path-to-pflua>
+--  $ unxz $pflua-bench/src/ts/pcaps/igalia/one-gigabyte.xz
+--  $ ln -fs $pflua-bench/src/ts/pcaps/igalia/one-gigabyte.xz
+--      $pflua/src/ts/pcaps/igalia/one-gigabyte.pcap
+--
+--]]
+
+module("pf_pcap_asm", package.seeall)
+
+local savefile = require("pf.savefile")
+local libpcap = require("pf.libpcap")
+local buffer = require("pf.buffer")
+local bpf = require("pf.bpf")
+
+-- Compiles pcap expression
+function compile_pcap_filter(filter_str, dlt_name)
+   return bpf.compile(libpcap.compile(filter_str, dlt_name))
+end
+
+-- Counts number of packets within file
+function filter_count(pred, file)
+   local total_pkt = 0
+   local count = 0
+   local records = savefile.records_mm(file)
+
+   while true do
+      local pkt, hdr = records()
+      if not pkt then break end
+
+      local packets = buffer.from_uchar(pkt, hdr.incl_len)
+      execute_pred_ensuring_trace(pred, packets)
+   end
+   return count, total_pkt
+end
+
+-- Executing pred within a function ensures a trace for this call
+function execute_pred_ensuring_trace(pred, packets)
+    pred(packets)
+end
+
+-- Calls func() during seconds
+function call_during_seconds(seconds, func, pred, file)
+    local time = os.time
+    local finish = time() + seconds
+    while (true) do
+        func(pred, file)
+        if (time() > finish) then break end
+    end
+end
+
+function selftest(filter)
+   print("selftest: pf_pcap_asm")
+
+   local file = "ts/pcaps/igalia/one-gigabyte.pcap"
+   if (filter == nil or filter == '') then
+      filter = "tcp port 80"
+   end
+   local dlt = "EN10MB"
+
+   local pred = compile_pcap_filter(filter, dlt)
+   call_during_seconds(1, filter_count, pred, file)
+
+   print("OK")
+end


### PR DESCRIPTION
Example of use:

$ ./pf_pcap_asm
$ ./pf_pcap_asm "<pcap-expression>" (default "tcp port 80")

NOTE: The file used for packet filtering is a 1GB file from pflua-bench, so
it's necessary to clone that repo, uncompress the file and create a symbolic
link to it. See instructions in src/pf_pcap_asm.lua.
