### PR TITLE
parse_optional_int should return table with token and optional int

### DIFF
--- a/src/pf/parse.lua
+++ b/src/pf/parse.lua
@@ -431,9 +431,9 @@ end
 
 local function parse_optional_int(lexer, tok)
    if (type(lexer.peek()) == 'number') then
-      return parser(tok, lexer.next())
+      return { tok, lexer.next() }
    end
-   return parser(tok)
+   return { tok }
 end
 
 local src_or_dst_types = {


### PR DESCRIPTION
There is an error in the function that checks whether a token accepts an optional int value. This affects the protocol that may accept an optional integer as extra parameter.
