### PR TITLE
Implement iso operators 'clnp, 'esis' and 'isis'

### DIFF
--- a/src/pf/expand.lua
+++ b/src/pf/expand.lua
@@ -84,6 +84,18 @@ local function has_ip_protocol(proto)
             has_ipv4_protocol(proto),
             { 'and', { 'ip6' }, has_ipv6_protocol(proto) } }
 end
+local function is_iso_protocol()
+   return { 'and',
+             { '>', { '[ether]', 12, 2 }, 1500 },
+             { '=', { '[ip]', 0, 2 }, 65528 },
+          }
+end
+local function has_iso_protocol(proto)
+   return { 'and',
+            is_iso_protocol(),
+            { '=', { '[ip]', 3, 1 }, proto }
+          }
+end
 
 local primitive_expanders = {
    dst_host = unimplemented,
@@ -166,7 +178,7 @@ local primitive_expanders = {
    decnet_src = unimplemented,
    decnet_dst = unimplemented,
    decnet_host = unimplemented,
-   iso = unimplemented,
+   iso = unimplemented, -- FIXME(wingo): parse error
    stp = unimplemented,
    ipx = unimplemented,
    netbeui = unimplemented,
@@ -199,9 +211,9 @@ local primitive_expanders = {
    pppoed = unimplemented,
    pppoes = unimplemented,
    iso_proto = unimplemented,
-   clnp = unimplemented,
-   esis = unimplemented,
-   isis = unimplemented,
+   clnp = function(expr) return has_iso_protocol(129) end,
+   esis = function(expr) return has_iso_protocol(130) end,
+   isis = function(expr) return has_iso_protocol(131) end,
    l1 = unimplemented,
    l2 = unimplemented,
    iih = unimplemented,


### PR DESCRIPTION
This pull-request depends on the parse-optional-int pull request.

**clnp**

BPF code:

```
(000) ldh      [12]
(001) jgt      #0x5dc           jt 7    jf 2
(002) ldh      [14]
(003) jeq      #0xfefe          jt 4    jf 7
(004) ldb      [17]
(005) jeq      #0x81            jt 6    jf 7
(006) ret      #65535
(007) ret      #0
```

Lua code:

```
return function(P,length)
   if not (18 <= length) then return false end
   local v1 = ffi.cast("uint16_t*", P+12)[0]
   local v2 = bit.rshift(bit.bswap(v1), 16)
   if not (v2 > 1500) then return false end
   do
      if not (v1 == 8) then return false end
      local v3 = ffi.cast("uint16_t*", P+14)[0]
      if not (v3 == 63743) then return false end
   end
   do
      if not (v1 == 8) then return false end
      local v4 = P[17]
      do return v4 == 129 end
   end
end
```

**esis**

BPF code:

```
(000) ldh      [12]
(001) jgt      #0x5dc           jt 7    jf 2
(002) ldh      [14]
(003) jeq      #0xfefe          jt 4    jf 7
(004) ldb      [17]
(005) jeq      #0x82            jt 6    jf 7
(006) ret      #65535
(007) ret      #0
```

Lua code:

```
return function(P,length)
   if not (18 <= length) then return false end
   local v1 = ffi.cast("uint16_t*", P+12)[0]
   local v2 = bit.rshift(bit.bswap(v1), 16)
   if not (v2 > 1500) then return false end
   do
      if not (v1 == 8) then return false end
      local v3 = ffi.cast("uint16_t*", P+14)[0]
      if not (v3 == 63743) then return false end
   end
   do
      if not (v1 == 8) then return false end
      local v4 = P[17]
      do return v4 == 130 end
   end
end
```

**isis**

BPF code:

```
(000) ldh      [12]
(001) jgt      #0x5dc           jt 7    jf 2
(002) ldh      [14]
(003) jeq      #0xfefe          jt 4    jf 7
(004) ldb      [17]
(005) jeq      #0x83            jt 6    jf 7
(006) ret      #65535
(007) ret      #0
```

Lua code:

```
return function(P,length)
   if not (18 <= length) then return false end
   local v1 = ffi.cast("uint16_t*", P+12)[0]
   local v2 = bit.rshift(bit.bswap(v1), 16)
   if not (v2 > 1500) then return false end
   do
      if not (v1 == 8) then return false end
      local v3 = ffi.cast("uint16_t*", P+14)[0]
      if not (v3 == 63743) then return false end
   end
   do
      if not (v1 == 8) then return false end
      local v4 = P[17]
      do return v4 == 131 end
   end
end
```
