### PR TITLE
Implement operators 'atalk' and 'aarp'

### DIFF
--- a/src/pf/expand.lua
+++ b/src/pf/expand.lua
@@ -161,8 +161,30 @@ local primitive_expanders = {
    protochain = unimplemented,
    arp = function(expr) return has_ether_protocol(2054) end,
    rarp = function(expr) return has_ether_protocol(32821) end,
-   atalk = unimplemented,
-   aarp = unimplemented,
+   atalk = function(expr)
+       return { 'and',
+                { 'or',
+                   { '=', { '[ether]', 12, 2 }, 32923 },
+                   { '>', { '[ether]', 12, 2 }, 1500 },
+                },
+                { 'and',
+                   { '=', { '[ip]', 4, 2 }, 30729 },
+                   { '=', { '[ip]', 0, 4 }, 2863268616 }
+                }
+              }
+   end,
+   aarp = function(expr)
+       return { 'and',
+                { 'or',
+                   { '=', { '[ether]', 12, 2 }, 33011 },
+                   { '>', { '[ether]', 12, 2 }, 1500 },
+                },
+                { 'and',
+                   { '=', { '[ip]', 4, 2 }, 32883 },
+                   { '=', { '[ip]', 0, 4 }, 2863268608 }
+                }
+              }
+   end,
    decnet_src = unimplemented,
    decnet_dst = unimplemented,
    decnet_host = unimplemented,


### PR DESCRIPTION
I have some doubts with this one. Both functions have a similar structure. Here is the BPF code and Lua code for each function:

**atalk**

BPF code:

```
(000) ldh      [12]
(001) jeq      #0x809b          jt 7    jf 2
(002) jgt      #0x5dc           jt 8    jf 3
(003) ld       [18]
(004) jeq      #0x7809b         jt 5    jf 8
(005) ld       [14]
(006) jeq      #0xaaaa0308      jt 7    jf 8
(007) ret      #65535
(008) ret      #0
```

Lua code:

```
return function(P,length)
   if not (20 <= length) then return false end
   local v1 = ffi.cast("uint16_t*", P+12)[0]
   if v1 == 39808 then goto L1 end
   do
      local v2 = bit.rshift(bit.bswap(v1), 16)
      if not (v2 > 1500) then return false end
   end
::L1::
   do
      if not (v1 == 8) then return false end
      local v3 = ffi.cast("uint16_t*", P+18)[0]
      if not (v3 == 2424) then return false end
      do
         local v4 = ffi.cast("int32_t*", P+14)[0]
         do return v4 == 134458026 end
      end
   end
end
```

**aarp**

BPF code:

```
(000) ldh      [12]
(001) jeq      #0x80f3          jt 7    jf 2
(002) jgt      #0x5dc           jt 8    jf 3
(003) ld       [18]
(004) jeq      #0x80f3          jt 5    jf 8
(005) ld       [14]
(006) jeq      #0xaaaa0300      jt 7    jf 8
(007) ret      #65535
(008) ret      #0
```

Lua code:

```
return function(P,length)
   if not (20 <= length) then return false end
   local v1 = ffi.cast("uint16_t*", P+12)[0]
   if v1 == 62336 then goto L1 end
   do
      local v2 = bit.rshift(bit.bswap(v1), 16)
      if not (v2 > 1500) then return false end
   end
::L1::
   do
      if not (v1 == 8) then return false end
      local v3 = ffi.cast("uint16_t*", P+18)[0]
      if not (v3 == 29568) then return false end
      do
         local v4 = ffi.cast("int32_t*", P+14)[0]
         do return v4 == 240298 end
      end
   end
end
```
