### PR TITLE
Implement operator 'stp'

### DIFF
--- a/src/pf/expand.lua
+++ b/src/pf/expand.lua
@@ -84,6 +84,12 @@ local function has_ip_protocol(proto)
             has_ipv4_protocol(proto),
             { 'and', { 'ip6' }, has_ipv6_protocol(proto) } }
 end
+local function is_stp_protocol()
+   return { 'and',
+             { '>', { '[ether]', 12, 2 }, 1500 },
+             { '=', { '[ip]', 0, 1 }, 66 },
+          }
+end
 
 local primitive_expanders = {
    dst_host = unimplemented,
@@ -167,7 +173,7 @@ local primitive_expanders = {
    decnet_dst = unimplemented,
    decnet_host = unimplemented,
    iso = unimplemented,
-   stp = unimplemented,
+   stp = is_stp_protocol,
    ipx = unimplemented,
    netbeui = unimplemented,
    lat = unimplemented,


### PR DESCRIPTION
BPF code:

```
(000) ldh      [12]
(001) jgt      #0x5dc           jt 5    jf 2
(002) ldb      [14]
(003) jeq      #0x42            jt 4    jf 5
(004) ret      #65535
(005) ret      #0
```

Lua code:

```
return function(P,length)
   if not (15 <= length) then return false end
   local v1 = ffi.cast("uint16_t*", P+12)[0]
   local v2 = bit.rshift(bit.bswap(v1), 16)
   if not (v2 > 1500) then return false end
   do
      if not (v1 == 8) then return false end
      local v3 = P[14]
      do return v3 == 66 end
   end
end
```

I don't understand the check "v1 == 8", it doesn't seem to appear in the BPF code.
