### PR TITLE
Implement operator 'vlan'

### DIFF
--- a/src/pf/expand.lua
+++ b/src/pf/expand.lua
@@ -194,7 +194,12 @@ local primitive_expanders = {
    type_subtype = unimplemented,
    subtype = unimplemented,
    dir = unimplemented,
-   vlan = unimplemented,
+   vlan = function(expr)
+      return { 'or',
+                has_ether_protocol(33024),
+                has_ether_protocol(37120)
+             }
+   end,
    mpls = unimplemented,
    pppoed = unimplemented,
    pppoes = unimplemented,


### PR DESCRIPTION
This pull-request depends on the parse-optional-int pull-request.

BPF code

```
(000) ldh      [12]
(001) jeq      #0x8100          jt 3    jf 2
(002) jeq      #0x9100          jt 3    jf 4
(003) ret      #65535
(004) ret      #0
```

Lua code:

```
return function(P,length)
   if not (14 <= length) then return false end
   local v1 = ffi.cast("uint16_t*", P+12)[0]
   if v1 == 129 then return true end
   do
      do return v1 == 145 end
   end
end
```
