### PR TITLE
Fix cannot locate function 'compile_filter'.

### DIFF
--- a/utils/bpf-to-asm
+++ b/utils/bpf-to-asm
@@ -2,19 +2,38 @@
 
 PRINT=0
 
+usage() {
+cat << EOF
+Usage: $0 <bpf expression>
+
+    Prints out BPF asm code for a BPF expression.
+
+Options:
+    --help | -h         Prints this help.
+    <bpf expression>    BPF expression to compile. DEFAULT: "tcp port 80".
+
+See: http://biot.com/capstats/bpf.html 
+EOF
+}
+
+if [[ $1 == "--help" || $1 == "-h" ]]; then
+    usage
+    exit
+fi
+
 filter="tcp port 80"
 if [ $# == 1 ]; then
     filter=$1
 fi
 
 # Name of the script that prints out asm for a pred expression
-lua_script="pf_pcap_asm.lua"
+lua_script="bpf_to_asm.lua"
 
 # Linenumber where the 'execute_pred_ensuring_trace' function is defined
 lineno=`grep -n 'function execute_pred_ensuring_trace' $lua_script | cut -d : -f 1`
 
 # Iterate through all asm output but print out only the fragment of asm code for the compiled pred expression
-output=`luajit -jdump=m -l pf_pcap_asm -e 'pf_pcap_asm.selftest()'`;
+output=`luajit -jdump=m -l bpf_to_asm -e 'bpf_to_asm.selftest()'`;
 while read -r line; do
     # Was printing and found a blank line
     if [ $PRINT -eq 1 ] && [ -z "$line" ]; then

--- a/utils/bpf_to_asm.lua
+++ b/utils/bpf_to_asm.lua
@@ -15,16 +15,13 @@
 --
 --]]
 
-module("pf_pcap_asm", package.seeall)
+module("bpf_to_asm", package.seeall)
+
+package.path = package.path .. ";../src/?.lua"
 
 local savefile = require("pf.savefile")
 local libpcap = require("pf.libpcap")
-local bpf = require("pf.bpf")
-
--- Compiles pcap expression
-function compile_pcap_filter(filter_str, dlt_name)
-   return bpf.compile(libpcap.compile(filter_str, dlt_name))
-end
+local pf = require("pf")
 
 -- Counts number of packets within file
 function filter_count(pred, file)
@@ -58,14 +55,14 @@ function call_during_seconds(seconds, func, pred, file)
 end
 
 function selftest(filter)
-   print("selftest: pf_pcap_asm")
+   print("selftest: bpf_to_asm")
 
-   local file = "ts/pcaps/igalia/one-gigabyte.pcap"
+   local file = "../src/ts/pcaps/igalia/one-gigabyte.pcap"
    if (filter == nil or filter == '') then
       filter = "tcp port 80"
    end
 
-   local pred = compile_filter(filter, {dlt="EN10MB"})
+   local pred = pf.compile_filter(filter, {dlt="EN10MB"})
    call_during_seconds(1, filter_count, pred, file)
 
    print("OK")


### PR DESCRIPTION
When generating BPF asm, the path to function 'compile_filter' is broken. It's necesarry to import 'pf'.

Additional improvements:
- Removed unused code in 'pc_pcap_asm.lua'.
- Renamed script 'pc_pcap_asm' to 'bpf-to-asm'.
- Added usage information to 'bpf-to-asm'.
- Moved script to dir 'utils/'.
