### PR TITLE
Remove implicit conjunction

### DIFF
--- a/src/pf/parse.lua
+++ b/src/pf/parse.lua
@@ -745,12 +745,6 @@ local function parse_logical_or_arithmetic(lexer, max_precedence)
          if prec then
             if prec > max_precedence then return exp end
             lexer.consume(op)
-         else
-            -- The grammar is such that "tcp port 80" should actually
-            -- parse as "tcp and port 80".
-            op = 'and'
-            prec = 1
-            if prec > max_precedence then return exp end
          end
          local rhs = parse_logical(lexer, prec - 1)
          exp = { op, exp, rhs }


### PR DESCRIPTION
I thought that since "tcp port 80" should parse as "tcp and port 80" that in fact the implicit "and" that the pflang spec mentions as obsolete was in fact current.  This faulty conclusion was based on my bad understanding of how "tcp port 80" parses -- that in fact as issue #15 indicates, "tcp port 80" is one operator.

So, we should remove the implicit conjunctions from the parser.
