### PR TITLE
Optimize <= / >= for non-strict orderings

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -1,6 +1,6 @@
 PATH := ../deps/luajit/usr/local/bin:$(PATH)
 
-EXAMPLES = tcp-port-80.md icmp-or-tcp-or-udp.md
+EXAMPLES = tcp-port-80.md icmp-or-tcp-or-udp.md portrange-0-6000.md
 
 all: $(EXAMPLES)
 
@@ -12,3 +12,6 @@ tcp-port-80.md:
 
 icmp-or-tcp-or-udp.md:
 	../tools/dump-markdown "icmp or tcp or udp" > $@.tmp && mv $@.tmp $@
+
+portrange-0-6000.md:
+	../tools/dump-markdown "portrange 0-6000" > $@.tmp && mv $@.tmp $@

--- a/doc/portrange-0-6000.md
+++ b/doc/portrange-0-6000.md
@@ -1,0 +1,164 @@
+# portrange 0-6000
+
+
+## BPF
+
+```
+000: A = P[12:2]
+001: if (A == 34525) goto 2 else goto 11
+002: A = P[20:1]
+003: if (A == 132) goto 6 else goto 4
+004: if (A == 6) goto 6 else goto 5
+005: if (A == 17) goto 6 else goto 26
+006: A = P[54:2]
+007: if (A >= 0) goto 8 else goto 9
+008: if (A > 6000) goto 9 else goto 25
+009: A = P[56:2]
+010: if (A >= 0) goto 24 else goto 26
+011: if (A == 2048) goto 12 else goto 26
+012: A = P[23:1]
+013: if (A == 132) goto 16 else goto 14
+014: if (A == 6) goto 16 else goto 15
+015: if (A == 17) goto 16 else goto 26
+016: A = P[20:2]
+017: if (A & 8191 != 0) goto 26 else goto 18
+018: X = (P[14:1] & 0xF) << 2
+019: A = P[X+14:2]
+020: if (A >= 0) goto 21 else goto 22
+021: if (A > 6000) goto 22 else goto 25
+022: A = P[X+16:2]
+023: if (A >= 0) goto 24 else goto 26
+024: if (A > 6000) goto 26 else goto 25
+025: return 65535
+026: return 0
+```
+
+
+## BPF cross-compiled to Lua
+
+```
+return function (P, length)
+   local A = 0
+   local X = 0
+   local T = 0
+   if 14 > length then return 0 end
+   A = bit.bor(bit.lshift(P[12], 8), P[12+1])
+   if not (A==34525) then goto L10 end
+   if 21 > length then return 0 end
+   A = P[20]
+   if (A==132) then goto L5 end
+   if (A==6) then goto L5 end
+   if not (A==17) then goto L25 end
+   ::L5::
+   if 56 > length then return 0 end
+   A = bit.bor(bit.lshift(P[54], 8), P[54+1])
+   if not (runtime_u32(A)>=0) then goto L8 end
+   if not (runtime_u32(A)>6000) then goto L24 end
+   ::L8::
+   if 58 > length then return 0 end
+   A = bit.bor(bit.lshift(P[56], 8), P[56+1])
+   if (runtime_u32(A)>=0) then goto L23 end
+   goto L25
+   ::L10::
+   if not (A==2048) then goto L25 end
+   if 24 > length then return 0 end
+   A = P[23]
+   if (A==132) then goto L15 end
+   if (A==6) then goto L15 end
+   if not (A==17) then goto L25 end
+   ::L15::
+   if 22 > length then return 0 end
+   A = bit.bor(bit.lshift(P[20], 8), P[20+1])
+   if not (bit.band(A, 8191)==0) then goto L25 end
+   if 14 >= length then return 0 end
+   X = bit.lshift(bit.band(P[14], 15), 2)
+   T = bit.tobit((X+14))
+   if T < 0 or T + 2 > length then return 0 end
+   A = bit.bor(bit.lshift(P[T], 8), P[T+1])
+   if not (runtime_u32(A)>=0) then goto L21 end
+   if not (runtime_u32(A)>6000) then goto L24 end
+   ::L21::
+   T = bit.tobit((X+16))
+   if T < 0 or T + 2 > length then return 0 end
+   A = bit.bor(bit.lshift(P[T], 8), P[T+1])
+   if not (runtime_u32(A)>=0) then goto L25 end
+   ::L23::
+   if (runtime_u32(A)>6000) then goto L25 end
+   ::L24::
+   do return 65535 end
+   ::L25::
+   do return 0 end
+   error("end of bpf")
+end
+```
+
+
+## Direct pflang compilation
+
+```
+return function(P,length)
+   if not (24 <= length) then return false end
+   do
+      local v1 = ffi.cast("uint16_t*", P+12)[0]
+      if not (v1 == 8) then goto L3 end
+      do
+         local v2 = P[23]
+         if v2 == 6 then goto L4 end
+         do
+            if v2 == 17 then goto L4 end
+            do
+               if not (v2 == 132) then return false end
+            end
+         end
+::L4::
+         do
+            local v3 = ffi.cast("uint16_t*", P+20)[0]
+            local v4 = bit.band(v3,65311)
+            if not (v4 == 0) then return false end
+            do
+               local v5 = P[14]
+               local v6 = bit.band(v5,15)
+               local v7 = bit.lshift(v6,2)
+               local v8 = v7+16
+               if not (v8 <= length) then return false end
+               do
+                  local v9 = v7+14
+                  local v10 = ffi.cast("uint16_t*", P+v9)[0]
+                  local v11 = bit.rshift(bit.bswap(v10), 16)
+                  if v11 <= 6000 then return true end
+                  do
+                     local v12 = v7+18
+                     if not (v12 <= length) then return false end
+                     do
+                        local v13 = ffi.cast("uint16_t*", P+v8)[0]
+                        local v14 = bit.rshift(bit.bswap(v13), 16)
+                        do return v14 <= 6000 end
+                     end
+                  end
+               end
+            end
+         end
+      end
+::L3::
+      do
+         if not (55 <= length) then return false end
+         do
+            if not (v1 == 56710) then return false end
+            do
+               local v15 = P[20]
+               if v15 == 6 then return false end
+               do
+                  if not (v15 == 44) then return false end
+                  do
+                     local v16 = P[54]
+                     if v16 == 6 then return false end
+                     do return false end
+                  end
+               end
+            end
+         end
+      end
+   end
+end
+```
+

--- a/src/pf/optimize.lua
+++ b/src/pf/optimize.lua
@@ -445,6 +445,11 @@ local function infer_ranges(expr)
          if ((lhs_range:fold() and rhs_range:fold())
              or lhs_range:lt(rhs_range) or lhs_range:gt(rhs_range)) then
             return fold(lhs_range:min(), rhs_range:min())
+         elseif (lhs_range:max() == rhs_range:min() and op == '<='
+                 or lhs_range:min() == rhs_range:max() and op == '>=') then
+            -- The ranges are ordered, but not strictly, and in the same
+            -- sense as the test: the condition is true.
+            return { 'true' }
          end
          -- Otherwise, the relop may restrict the ranges for both
          -- arguments along both continuations.


### PR DESCRIPTION
- doc/Makefile:
- doc/portrange-0-6000.md: New example.
- src/pf/optimize.lua: Optimize <= and >= for ranges that are ordered,
  but not strictly so.
