### PR TITLE
Fix errors in parser

### DIFF
--- a/src/pf/parse.lua
+++ b/src/pf/parse.lua
@@ -20,7 +20,8 @@ end
 
 local punctuation = set(
    '(', ')', '[', ']', '!', '!=', '<', '<=', '>', '>=', '=',
-   '+', '-', '*', '/', '&', '|', '^', '&&', '||', '<<', '>>'
+   '+', '-', '*', '/', '&', '|', '^', '&&', '||', '<<', '>>',
+   '\\'
 )
 
 local function lex_host_or_keyword(str, pos)
@@ -416,9 +417,12 @@ local ether_protos = set(
 )
 
 local function parse_ether_proto_arg(lexer)
+   lexer.check('\\')
    local arg = lexer.next()
-   if type(arg) == 'number' or ether_protos[arg] then
-      return arg
+   if type(arg) == 'number' then return arg end
+   if type(arg) == 'string' then
+      local proto = arg:match("^(%w+)")
+      if ether_protos[proto] then return proto end
    end
    lexer.error('invalid ethernet proto %s', arg)
 end
@@ -428,9 +432,12 @@ local ip_protos = set(
 )
 
 local function parse_ip_proto_arg(lexer)
+   lexer.check('\\')
    local arg = lexer.next()
-   if type(arg) == 'number' or ip_protos[arg] then
-      return arg
+   if type(arg) == 'number' then return arg end
+   if type(arg) == 'string' then
+      local proto = arg:match("^(%w+)")
+      if ip_protos[proto] then return proto end
    end
    lexer.error('invalid ip proto %s', arg)
 end
@@ -880,6 +887,14 @@ function selftest ()
                 { 'ipv4/len', { 'ipv4', 10, 0, 0, 0 }, 24 }})
    parse_test("ether proto rarp",
               { 'ether_proto', 'rarp' })
+   parse_test("ether proto \\rarp",
+              { 'ether_proto', 'rarp' })
+   parse_test("ip proto tcp",
+              { 'ip_proto', 'tcp' })
+   parse_test("ip proto \\tcp",
+              { 'ip_proto', 'tcp' })
+   parse_test("ip proto \\0",
+              { 'ip_proto', 0 })
    parse_test("decnet host 10.23",
               { 'decnet_host', { 'decnet', 10, 23 } })
    parse_test("ip proto icmp",


### PR DESCRIPTION
- Argument of 'ether proto <proto>' and 'ip proto <proto>' could be escaped, i.e, "ip proto \arp".
- Function 'parse_optional_int' should return table with token and optional int.
