### PR TITLE
Remove dynamic allocations from filter loop

### DIFF
--- a/src/pf/savefile.lua
+++ b/src/pf/savefile.lua
@@ -49,7 +49,6 @@ function open_and_mmap(filename)
    end
 
    ptr = ffi.cast("unsigned char *", ptr)
-   local ptr_end = ptr + sz
    local header = ffi.cast("struct pcap_file *", ptr)
    if header.magic_number == 0xD4C3B2A1 then
       error("Endian mismatch in " .. filename)
@@ -57,7 +56,7 @@ function open_and_mmap(filename)
       error("Bad PCAP magic number in " .. filename)
    end
 
-   return header, ptr + ffi.sizeof("struct pcap_file"), ptr_end
+   return header, ptr + ffi.sizeof("struct pcap_file"), sz
 end
 
 function records_mm(filename)

--- a/tools/pflua-filter
+++ b/tools/pflua-filter
@@ -6,9 +6,8 @@ local ffi = require("ffi")
 local pf = require("pf")
 local savefile = require("pf.savefile")
 
-local function filter(ptr, ptr_end, out, pred)
+local function filter(ptr, max_offset, out, pred)
    local seen, written, offset = 0, 0, 0
-   local max_offset = ptr_end - ptr
    local pcap_record_size = ffi.sizeof("struct pcap_record")
    while offset < max_offset do
       local cur_ptr = ptr + offset

--- a/tools/pflua-match
+++ b/tools/pflua-match
@@ -7,9 +7,8 @@ local pf = require("pf")
 local utils = require("pf.utils")
 local savefile = require("pf.savefile")
 
-local function filter(ptr, ptr_end, pred)
+local function filter(ptr, max_offset, pred)
    local seen, matched, offset = 0, 0, 0
-   local max_offset = ptr_end - ptr
    local pcap_record_size = ffi.sizeof("struct pcap_record")
    while offset < max_offset do
       local cur_ptr = ptr + offset


### PR DESCRIPTION
Restructure the main filter loop so that ffi pointer values are not live at
control flow boundaries - that is, so they are confined to one trace.  This
allows luajit to sink (optimize out) the dynamic allocations. The result is
that all CNEWI calls are sunk, and a considerable performance improvement on
some workloads.

https://github.com/Igalia/pflua/issues/57
