### PR TITLE
Fix crash when compiling division by a power of 2 from BPF

### DIFF
--- a/src/pf/bpf.lua
+++ b/src/pf/bpf.lua
@@ -247,7 +247,7 @@ function compile_lua(bpf)
          assert(src == BPF_K, "division by non-constant value is unsupported")
          assert(k ~= 0, "program contains division by constant zero")
          local bits = is_power_of_2(k)
-         if bits then rhs = shr(A(), bits) else rhs = div(A(), k) end
+         if bits then rhs = rsh(A(), bits) else rhs = div(A(), k) end
       elseif op == BPF_OR  then rhs = bor(A(), b)
       elseif op == BPF_AND then rhs = band(A(), b)
       elseif op == BPF_LSH then rhs = lsh(A(), b)


### PR DESCRIPTION
Due to a typo pflua currently crashes when compiling from BPF if there is a division by a power of two.

Testcase:

``` bash
$ cd src
$ ../deps/luajit/usr/local/bin/luajit ../tools/pflang-compile --bpf-lua 'tcp and (ip[0]/4 != 0)'
```

Result before fix:

```
../deps/luajit/usr/local/bin/luajit: ./pf/bpf.lua:250: attempt to call global 'shr' (a nil value)
stack traceback:
    ./pf/bpf.lua:250: in function 'alu'
    ./pf/bpf.lua:317: in function 'compile_filter'
    ../tools/pflang-compile:47: in main chunk
    [C]: at 0x0804c020
```

Result after fix:

```
return function (P, length)
   local A = 0
   if 14 > length then return 0 end
   A = bit.bor(bit.lshift(P[12], 8), P[12+1])
   if (A==34525) then goto L8 end
   if not (A==2048) then goto L8 end
   if 24 > length then return 0 end
   A = P[23]
   if not (A==6) then goto L8 end
   if 15 > length then return 0 end
   A = P[14]
   A = bit.rshift(A, 2)
   if (A==0) then goto L8 end
   do return 65535 end
   ::L8::
   do return 0 end
   error("end of bpf")
end
```
