### PR TITLE
Fix parsing of logical expressions

### DIFF
--- a/src/pf/parse.lua
+++ b/src/pf/parse.lua
@@ -834,7 +834,7 @@ local function parse_logical_or_arithmetic(lexer, max_precedence)
 end
 
 function parse_logical(lexer, max_precedence)
-   local expr = parse_logical_or_arithmetic(lexer)
+   local expr = parse_logical_or_arithmetic(lexer, max_precedence)
    assert(not is_arithmetic(expr), "expected a logical expression")
    return expr
 end


### PR DESCRIPTION
Currently `parse_logical` does not pass `max_precedence` to `parse_logical_or_arithmetic`, and, as default `max_precedence` is `math.huge`, effectively all logical operators have same precedence and are right associative.

Testcase:

``` bash
$ cd tools
$ ../deps/luajit/usr/local/bin/luajit pflang-compile '0=1 and 0=0 or 0=0'
```

Result before fix:

```
return function(P,length)
   do return false end
end
```

Result after fix:

```
return function(P,length)
   do return true end
end
```

Also added a test for this.
