### PR TITLE
More accurate timing through more iterations

### DIFF
--- a/src/pf/utils.lua
+++ b/src/pf/utils.lua
@@ -2,7 +2,6 @@ module(...,package.seeall)
 
 local ffi = require("ffi")
 local C = ffi.C
-local bor, rshift = bit.bor, bit.rshift
 
 ffi.cdef[[
 typedef long time_t;
@@ -128,17 +127,6 @@ function fixpoint(f, expr)
    local prev
    repeat expr, prev = f(expr), expr until equals(expr, prev)
    return expr
-end
-
--- Algorithm from "Hacker's delight"
-function ceiling_power2(x)
-   x = x - 1
-   x = bor(x, rshift(x, 1))
-   x = bor(x, rshift(x, 2))
-   x = bor(x, rshift(x, 4))
-   x = bor(x, rshift(x, 8))
-   x = bor(x, rshift(x, 16))
-   return x + 1
 end
 
 function selftest ()

--- a/tools/pflua-match
+++ b/tools/pflua-match
@@ -40,29 +40,33 @@ function get_predicate(filter_input, opts)
    end
 end
 
+local function run_filter(min_time, packets, pred)
+   local start = utils.now()
+   local finish = start
+   local seen, matched = 0
+   local iterations = 0
+   while finish - start < min_time do
+      seen, matched = filter(packets, pred)
+      finish = utils.now()
+      iterations = iterations + 1
+   end
+   return seen, matched, (finish - start), iterations
+end
+
 function main(in_file, filter_input, opts)
    local packets = savefile.load_packets(in_file)
    local pred = get_predicate(filter_input, opts)
-   -- Warm up.
+   -- Untimed warm up - this may involve disk access, etc.
    filter(packets, pred)
-   -- Time one warm run
-   local start = utils.now()
-   local seen, matched = filter(packets, pred)
-   local elapsed = utils.now() - start
-   -- Very short timing runs are highly inaccurate.
-   -- Calculate iterations to take at least around 1s.
-   local iterations = utils.ceiling_power2(1 / elapsed)
-   -- Do the actual benchmarking on that many iterations
-   start = utils.now()
-   for i=1,iterations do
-      -- Seen and matched are the same for every run.
-      seen, matched = filter(packets, pred)
-   end
-   elapsed = utils.now() - start
+   -- Full warm-up, hopefully. 0.5s is a guess; most JIT will(?) occur.
+   local seen, matched = run_filter(0.5, packets, pred)
+   -- Very short timing runs are highly inaccurate. 0.002s is not ok.
+   -- By 1s, results are more consistent.
+   -- Seen and matched are the same for every run.
+   seen, matched, elapsed, iterations = run_filter(1, packets, pred)
    print(string.format("Matched %d/%d packets in %s iterations: %s (%f MPPS).",
                        matched, seen, iterations, in_file,
                        (seen * iterations / elapsed) / 1e6))
-
 end
 
 -- Parse args


### PR DESCRIPTION
Short benchmarks have more noisy jitter. Make tests take around 1-2s to
reduce the variance between runs.
