### PR TITLE
Proper truncating 32-bit multiplication

### DIFF
--- a/src/pf/anf.lua
+++ b/src/pf/anf.lua
@@ -7,7 +7,7 @@ local set, pp, dup = utils.set, utils.pp, utils.dup
 local relops = set('<', '<=', '=', '!=', '>=', '>')
 
 local binops = set(
-   '+', '-', '*', '/', '&', '|', '^', '<<', '>>'
+   '+', '-', '*', '*64', '/', '&', '|', '^', '<<', '>>'
 )
 local unops = set('ntohs', 'ntohl', 'uint32', 'int32')
 

--- a/src/pf/backend.lua
+++ b/src/pf/backend.lua
@@ -258,6 +258,8 @@ local function serialize(builder, stmt)
       elseif op == '+' then return '('..lhs..' + '..rhs..')'
       elseif op == '-' then return '('..lhs..' - '..rhs..')'
       elseif op == '*' then return '('..lhs..' * '..rhs..')'
+      elseif op == '*64' then
+         return 'tonumber(('..lhs..' * 1LL * '..rhs..') % '.. 2^32 ..')'
       elseif op == '/' then return 'floor('..lhs..' / '..rhs..')'
       elseif op == '&' then return 'band('..lhs..','..rhs..')'
       elseif op == '^' then return 'bxor('..lhs..','..rhs..')'

--- a/src/pf/expand.lua
+++ b/src/pf/expand.lua
@@ -962,10 +962,10 @@ local addressables = set(
 )
 
 local binops = set(
-   '+', '-', '*', '/', '&', '|', '^', '&&', '||', '<<', '>>'
+   '+', '-', '*', '*64', '/', '&', '|', '^', '&&', '||', '<<', '>>'
 )
 local associative_binops = set(
-   '+', '*', '&', '|', '^'
+   '+', '*', '*64', '&', '|', '^'
 )
 local bitops = set('&', '|', '^')
 local unops = set('ntohs', 'ntohl', 'uint32')
@@ -1048,6 +1048,10 @@ function expand_arith(expr, dlt)
 
    local op = expr[1]
    if binops[op] then
+      -- Use 64-bit multiplication by default.  The optimizer will
+      -- reduce this back to Lua's normal float multiplication if it
+      -- can.
+      if op == '*' then op = '*64' end
       local lhs, lhs_assertions = expand_arith(expr[2], dlt)
       local rhs, rhs_assertions = expand_arith(expr[3], dlt)
       -- Mod 2^32 to preserve uint32 range.

--- a/src/pf/optimize.lua
+++ b/src/pf/optimize.lua
@@ -12,10 +12,10 @@ local set, concat, dup, pp = utils.set, utils.concat, utils.dup, utils.pp
 local relops = set('<', '<=', '=', '!=', '>=', '>')
 
 local binops = set(
-   '+', '-', '*', '/', '&', '|', '^', '<<', '>>'
+   '+', '-', '*', '*64', '/', '&', '|', '^', '<<', '>>'
 )
 local associative_binops = set(
-   '+', '*', '&', '|', '^'
+   '+', '*', '*64', '&', '|', '^'
 )
 local bitops = set('&', '|', '^')
 local unops = set('ntohs', 'ntohl', 'uint32', 'int32')
@@ -31,6 +31,7 @@ local folders = {
    ['+'] = function(a, b) return a + b end,
    ['-'] = function(a, b) return a - b end,
    ['*'] = function(a, b) return a * b end,
+   ['*64'] = function(a, b) return tonumber((a * 1LL * b) % 2^32) end,
    ['/'] = function(a, b) return math.floor(a / b) end,
    ['&'] = function(a, b) return bit.band(a, b) end,
    ['^'] = function(a, b) return bit.bxor(a, b) end,
@@ -309,6 +310,7 @@ local function Range(min, max)
    function ret.add(lhs, rhs) return lhs:binary(rhs, '+') end
    function ret.sub(lhs, rhs) return lhs:binary(rhs, '-') end
    function ret.mul(lhs, rhs) return lhs:binary(rhs, '*') end
+   function ret.mul64(lhs, rhs) return lhs:binary(rhs, '*64') end
    function ret.div(lhs, rhs)
       local rhs_min, rhs_max = rhs:min(), rhs:max()
       -- 0 is prohibited by assertions, so we won't hit it at runtime,
@@ -491,6 +493,7 @@ local function infer_ranges(expr)
       if op == '+' then return lhs:add(rhs) end
       if op == '-' then return lhs:sub(rhs) end
       if op == '*' then return lhs:mul(rhs) end
+      if op == '*64' then return lhs:mul64(rhs) end
       if op == '/' then return lhs:div(rhs) end
       if op == '&' then return lhs:band(rhs) end
       if op == '|' then return lhs:bor(rhs) end

--- a/tests/pfquickcheck/pflang_math.lua
+++ b/tests/pfquickcheck/pflang_math.lua
@@ -14,12 +14,9 @@ local utils = require("pf.utils")
 -- Generate pflang arithmetic
 local PflangNumber, PflangSmallNumber, PflangOp
 function PflangNumber() return math.random(0, 2^32-1) end
--- TODO: remove PflangSmallNumber; it's a workaround to avoid triggering
--- https://github.com/Igalia/pflua/issues/83 (float and integer muls diverge)
-function PflangSmallNumber() return math.random(0, 2^17) end
 function PflangOp() return utils.choose({ '+', '-', '*', '/' }) end
 function PflangArithmetic()
-   return { PflangNumber(), PflangOp(), PflangSmallNumber() }
+   return { PflangNumber(), PflangOp(), PflangNumber() }
 end
 
 -- Evaluate math expressions with libpcap and pflang's IR


### PR DESCRIPTION
* src/pf/anf.lua:
* src/pf/backend.lua:
* src/pf/optimize.lua:
* src/pf/expand.lua: Add *64 op, for 64-bit multiplication.  The
  expander will produce this op for all multiplications, and the
  optimizer may later reduce it to '*'.

* tests/pfquickcheck/pflang_math.lua: Update to work on the full range
  of numbers.