### PR TITLE
Test quickcheck's ability to make reproducible randomness

### DIFF
--- a/src/pf/quickcheck.lua
+++ b/src/pf/quickcheck.lua
@@ -1,6 +1,6 @@
 module(...,package.seeall)
 
-local gmtime = require('pf.utils').gmtime
+local utils = require('pf.utils')
 
 local program_name = 'pflua-quickcheck'
 
@@ -17,7 +17,7 @@ function initialize(options)
       options.seed, options.iterations, options.prop_name, options.prop_args
 
    if not seed then
-      seed = math.floor(gmtime() * 1e6) % 10^9
+      seed = math.floor(utils.gmtime() * 1e6) % 10^9
       print("Using time as seed: "..seed)
    end
    math.randomseed(assert(tonumber(seed)))
@@ -82,13 +82,16 @@ function run()
           rerun_usage(i)
           os.exit(1)
       end
-      if expected ~= got then
+      if not utils.equals(expected, got) then
           print("The property was falsified.")
           -- If the property file has extra info available, show it
           if prop.print_extra_information then
              prop.print_extra_information()
           else
-             print(("Expected: %s\nGot:      %s"):format(expected, got))
+             print('Expected:')
+             utils.pp(expected)
+             print('Got:')
+             utils.pp(got)
           end
           rerun_usage(i)
           os.exit(1)

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -15,6 +15,7 @@ $(TEST_SAVEFILE):
 quickcheck: $(TEST_SAVEFILE)
 	# $(PFLUA_QUICKCHECK) properties/opt_eq_unopt $(TEST_SAVEFILE) test-filters # Fix NaN bug
 	# $(PFLUA_QUICKCHECK) properties/opt_eq_unopt $(TEST_SAVEFILE) # Fix NaN bug
+	$(PFLUA_QUICKCHECK) properties/repeatable_randomization
 	$(PFLUA_QUICKCHECK) properties/pflua_math_eq_libpcap_math
 
 .SERIAL: all

--- a/tests/pfquickcheck/pflua_ir.lua
+++ b/tests/pfquickcheck/pflua_ir.lua
@@ -45,8 +45,8 @@ end
 function Comparison()
    local asserts = {}
    local expr = { ComparisonOp(), Arithmetic(asserts), Arithmetic(asserts) }
-   while #asserts > 0 do
-      expr = { 'if', table.remove(asserts), expr, { 'fail' } }
+   for i=#asserts,1,-1 do
+      expr = { 'if', asserts[i], expr, { 'fail' } }
    end
    return expr
 end

--- a/tests/properties/repeatable_randomization.lua
+++ b/tests/properties/repeatable_randomization.lua
@@ -1,0 +1,20 @@
+#!/usr/bin/env luajit
+-- -*- lua -*-
+module(..., package.seeall)
+package.path = package.path .. ";../?.lua;../../src/?.lua"
+
+local pflua_ir = require('pfquickcheck.pflua_ir')
+
+local function generate(seed)
+   math.randomseed(seed)
+   local res
+   -- Loop a few times so that we stress JIT compilation; see
+   -- https://github.com/Igalia/pflua/issues/77.
+   for i=1,100 do res = pflua_ir.Logical() end
+   return res
+end
+
+function property(packets, filter_list)
+   local seed = math.random()
+   return generate(seed), generate(seed)
+end


### PR DESCRIPTION
* src/pf/quickcheck.lua: Use utils.equals to check equality, and pp to
  print, by default.

* src/pf/utils.lua: Add ability to print arrays whose head is not a
  string, and a place to put a full table pretty-printer.

* tests/properties/repeatable_randomization.lua: New test, that our
  randomized IR structures can be repeatably generated.

* tests/Makefile: Add new test.