### PR TITLE
Remove "NYI: bytecode" in backend.lua, expand.lua and ssa.lua

### DIFF
--- a/src/pf/ssa.lua
+++ b/src/pf/ssa.lua
@@ -237,15 +237,15 @@ end
 -- Add a "preds" property to all blocks, which is a list of labels of
 -- predecessors.
 local function add_predecessors(ssa)
+   local function add_predecessor(succ, label)
+      table.insert(ssa.blocks[succ].preds, label)
+   end
    local function visit(label, block)
-      local function add_predecessor(succ)
-         table.insert(ssa.blocks[succ].preds, label)
-      end
       if block.control[1] == 'if' then
-         add_predecessor(block.control[3])
-         add_predecessor(block.control[4])
+         add_predecessor(block.control[3], label)
+         add_predecessor(block.control[4], label)
       elseif block.control[1] == 'goto' then
-         add_predecessor(block.control[2])
+         add_predecessor(block.control[2], label)
       else
          assert(block.control[1] == 'return')
       end


### PR DESCRIPTION
The following patches remove several "NYI: bytecode 50" and "NYI: bytecode 51" in backend.lua, expand.lua and ssa.lua. 

Bytecode 50 (UCLO) and bytecode 51 (FNEW) are involved when create closures, a function inside another function that has access to an upvalue. Moving the function out, makes unnecessary create a closure, solving the issue.

Number of traces aborted due to unimplemented bytecodes: 

**Master**
```
Step 1: 144
Step 2: 112
Step 3: 171
Step 4: 152
Step 5: 152
Step 6: 135
Step 7: 141
Step 8: 141
Step 9: 130
Step 10: 166
```
AVG: 144

**Patch applied**
```
Step 1: 117
Step 2: 129
Step 3: 102
Step 4: 143
Step 5: 130
Step 6: 116
Step 7: 111
Step 8: 143
Step 9: 147
Step 10: 148
```
AVG: 128

I integrated this change in Snabbswitch and to be honest I saw no difference:

**Pflua (master)**
```
Step 1: 45015040
Step 2: 35151872
Step 3: 32120832
Step 4: 40738816
Step 5: 34111488
Step 6: 35086336
Step 7: 48889856
Step 8: 47628288
Step 9: 47874048
Step 10: 47267840
```
AVG: 45,624.320

**Pflua (remove-NYI)**
```
Step 1: 50470912
Step 2: 48439296
Step 3: 35045376
Step 4: 31178752
Step 5: 40337408
Step 6: 50159616
Step 7: 50176000
Step 8: 32202752
Step 9: 28549120
Step 10: 49717248
```
AVG: 45,725.696