### PR TITLE
Make Lua function compiled via BPF return true or false

### DIFF
--- a/doc/decnet-host-10.15.md
+++ b/doc/decnet-host-10.15.md
@@ -56,76 +56,76 @@
 ```
 return function (P, length)
    local A = 0
-   if 14 > length then return 0 end
+   if 14 > length then return false end
    A = bit.bor(bit.lshift(P[12], 8), P[12+1])
    if not (A==24579) then goto L42 end
-   if 17 > length then return 0 end
+   if 17 > length then return false end
    A = P[16]
    A = bit.band(A, 7)
    if not (A==2) then goto L6 end
-   if 21 > length then return 0 end
+   if 21 > length then return false end
    A = bit.bor(bit.lshift(P[19], 8), P[19+1])
    if (A==3880) then goto L41 end
    ::L6::
-   if 18 > length then return 0 end
+   if 18 > length then return false end
    A = bit.bor(bit.lshift(P[16], 8), P[16+1])
    A = bit.band(A, 65287)
    if not (A==33026) then goto L11 end
-   if 22 > length then return 0 end
+   if 22 > length then return false end
    A = bit.bor(bit.lshift(P[20], 8), P[20+1])
    if (A==3880) then goto L41 end
    ::L11::
-   if 17 > length then return 0 end
+   if 17 > length then return false end
    A = P[16]
    A = bit.band(A, 7)
    if not (A==6) then goto L16 end
-   if 33 > length then return 0 end
+   if 33 > length then return false end
    A = bit.bor(bit.lshift(P[31], 8), P[31+1])
    if (A==3880) then goto L41 end
    ::L16::
-   if 18 > length then return 0 end
+   if 18 > length then return false end
    A = bit.bor(bit.lshift(P[16], 8), P[16+1])
    A = bit.band(A, 65287)
    if not (A==33030) then goto L21 end
-   if 34 > length then return 0 end
+   if 34 > length then return false end
    A = bit.bor(bit.lshift(P[32], 8), P[32+1])
    if (A==3880) then goto L41 end
    ::L21::
-   if 17 > length then return 0 end
+   if 17 > length then return false end
    A = P[16]
    A = bit.band(A, 7)
    if not (A==2) then goto L26 end
-   if 19 > length then return 0 end
+   if 19 > length then return false end
    A = bit.bor(bit.lshift(P[17], 8), P[17+1])
    if (A==3880) then goto L41 end
    ::L26::
-   if 18 > length then return 0 end
+   if 18 > length then return false end
    A = bit.bor(bit.lshift(P[16], 8), P[16+1])
    A = bit.band(A, 65287)
    if not (A==33026) then goto L31 end
-   if 20 > length then return 0 end
+   if 20 > length then return false end
    A = bit.bor(bit.lshift(P[18], 8), P[18+1])
    if (A==3880) then goto L41 end
    ::L31::
-   if 17 > length then return 0 end
+   if 17 > length then return false end
    A = P[16]
    A = bit.band(A, 7)
    if not (A==6) then goto L36 end
-   if 25 > length then return 0 end
+   if 25 > length then return false end
    A = bit.bor(bit.lshift(P[23], 8), P[23+1])
    if (A==3880) then goto L41 end
    ::L36::
-   if 18 > length then return 0 end
+   if 18 > length then return false end
    A = bit.bor(bit.lshift(P[16], 8), P[16+1])
    A = bit.band(A, 65287)
    if not (A==33030) then goto L42 end
-   if 26 > length then return 0 end
+   if 26 > length then return false end
    A = bit.bor(bit.lshift(P[24], 8), P[24+1])
    if not (A==3880) then goto L42 end
    ::L41::
-   do return 65535 end
+   do return true end
    ::L42::
-   do return 0 end
+   do return false end
    error("end of bpf")
 end
 ```

--- a/doc/decnet-src-10.15.md
+++ b/doc/decnet-src-10.15.md
@@ -36,44 +36,44 @@
 ```
 return function (P, length)
    local A = 0
-   if 14 > length then return 0 end
+   if 14 > length then return false end
    A = bit.bor(bit.lshift(P[12], 8), P[12+1])
    if not (A==24579) then goto L22 end
-   if 17 > length then return 0 end
+   if 17 > length then return false end
    A = P[16]
    A = bit.band(A, 7)
    if not (A==2) then goto L6 end
-   if 21 > length then return 0 end
+   if 21 > length then return false end
    A = bit.bor(bit.lshift(P[19], 8), P[19+1])
    if (A==3880) then goto L21 end
    ::L6::
-   if 18 > length then return 0 end
+   if 18 > length then return false end
    A = bit.bor(bit.lshift(P[16], 8), P[16+1])
    A = bit.band(A, 65287)
    if not (A==33026) then goto L11 end
-   if 22 > length then return 0 end
+   if 22 > length then return false end
    A = bit.bor(bit.lshift(P[20], 8), P[20+1])
    if (A==3880) then goto L21 end
    ::L11::
-   if 17 > length then return 0 end
+   if 17 > length then return false end
    A = P[16]
    A = bit.band(A, 7)
    if not (A==6) then goto L16 end
-   if 33 > length then return 0 end
+   if 33 > length then return false end
    A = bit.bor(bit.lshift(P[31], 8), P[31+1])
    if (A==3880) then goto L21 end
    ::L16::
-   if 18 > length then return 0 end
+   if 18 > length then return false end
    A = bit.bor(bit.lshift(P[16], 8), P[16+1])
    A = bit.band(A, 65287)
    if not (A==33030) then goto L22 end
-   if 34 > length then return 0 end
+   if 34 > length then return false end
    A = bit.bor(bit.lshift(P[32], 8), P[32+1])
    if not (A==3880) then goto L22 end
    ::L21::
-   do return 65535 end
+   do return true end
    ::L22::
-   do return 0 end
+   do return false end
    error("end of bpf")
 end
 ```

--- a/doc/dst-host-192.68.1.1-and-greater-100.md
+++ b/doc/dst-host-192.68.1.1-and-greater-100.md
@@ -24,10 +24,10 @@
 ```
 return function (P, length)
    local A = 0
-   if 14 > length then return 0 end
+   if 14 > length then return false end
    A = bit.bor(bit.lshift(P[12], 8), P[12+1])
    if not (A==2048) then goto L3 end
-   if 34 > length then return 0 end
+   if 34 > length then return false end
    A = bit.bor(bit.lshift(P[30], 24),bit.lshift(P[30+1], 16), bit.lshift(P[30+2], 8), P[30+3])
    if (A==-1069285119) then goto L7 end
    goto L10
@@ -35,15 +35,15 @@ return function (P, length)
    if (A==2054) then goto L5 end
    if not (A==32821) then goto L10 end
    ::L5::
-   if 42 > length then return 0 end
+   if 42 > length then return false end
    A = bit.bor(bit.lshift(P[38], 24),bit.lshift(P[38+1], 16), bit.lshift(P[38+2], 8), P[38+3])
    if not (A==-1069285119) then goto L10 end
    ::L7::
    A = bit.tobit(length)
    if not (runtime_u32(A)>=100) then goto L10 end
-   do return 65535 end
+   do return true end
    ::L10::
-   do return 0 end
+   do return false end
    error("end of bpf")
 end
 ```

--- a/doc/dst-portrange-80-90.md
+++ b/doc/dst-portrange-80-90.md
@@ -35,41 +35,41 @@ return function (P, length)
    local A = 0
    local X = 0
    local T = 0
-   if 14 > length then return 0 end
+   if 14 > length then return false end
    A = bit.bor(bit.lshift(P[12], 8), P[12+1])
    if not (A==34525) then goto L7 end
-   if 21 > length then return 0 end
+   if 21 > length then return false end
    A = P[20]
    if (A==132) then goto L5 end
    if (A==6) then goto L5 end
    if not (A==17) then goto L19 end
    ::L5::
-   if 58 > length then return 0 end
+   if 58 > length then return false end
    A = bit.bor(bit.lshift(P[56], 8), P[56+1])
    if (runtime_u32(A)>=80) then goto L17 end
    goto L19
    ::L7::
    if not (A==2048) then goto L19 end
-   if 24 > length then return 0 end
+   if 24 > length then return false end
    A = P[23]
    if (A==132) then goto L12 end
    if (A==6) then goto L12 end
    if not (A==17) then goto L19 end
    ::L12::
-   if 22 > length then return 0 end
+   if 22 > length then return false end
    A = bit.bor(bit.lshift(P[20], 8), P[20+1])
    if not (bit.band(A, 8191)==0) then goto L19 end
-   if 14 >= length then return 0 end
+   if 14 >= length then return false end
    X = bit.lshift(bit.band(P[14], 15), 2)
    T = bit.tobit((X+16))
-   if T < 0 or T + 2 > length then return 0 end
+   if T < 0 or T + 2 > length then return false end
    A = bit.bor(bit.lshift(P[T], 8), P[T+1])
    if not (runtime_u32(A)>=80) then goto L19 end
    ::L17::
    if (runtime_u32(A)>90) then goto L19 end
-   do return 65535 end
+   do return true end
    ::L19::
-   do return 0 end
+   do return false end
    error("end of bpf")
 end
 ```

--- a/doc/ether-broadcast.md
+++ b/doc/ether-broadcast.md
@@ -18,15 +18,15 @@
 ```
 return function (P, length)
    local A = 0
-   if 6 > length then return 0 end
+   if 6 > length then return false end
    A = bit.bor(bit.lshift(P[2], 24),bit.lshift(P[2+1], 16), bit.lshift(P[2+2], 8), P[2+3])
    if not (A==-1) then goto L4 end
-   if 2 > length then return 0 end
+   if 2 > length then return false end
    A = bit.bor(bit.lshift(P[0], 8), P[0+1])
    if not (A==65535) then goto L4 end
-   do return 65535 end
+   do return true end
    ::L4::
-   do return 0 end
+   do return false end
    error("end of bpf")
 end
 ```

--- a/doc/ether-multicast.md
+++ b/doc/ether-multicast.md
@@ -16,12 +16,12 @@
 ```
 return function (P, length)
    local A = 0
-   if 1 > length then return 0 end
+   if 1 > length then return false end
    A = P[0]
    if (bit.band(A, 1)==0) then goto L2 end
-   do return 65535 end
+   do return true end
    ::L2::
-   do return 0 end
+   do return false end
    error("end of bpf")
 end
 ```

--- a/doc/ether-proto-1500.md
+++ b/doc/ether-proto-1500.md
@@ -18,15 +18,15 @@
 ```
 return function (P, length)
    local A = 0
-   if 14 > length then return 0 end
+   if 14 > length then return false end
    A = bit.bor(bit.lshift(P[12], 8), P[12+1])
    if (runtime_u32(A)>1500) then goto L4 end
-   if 15 > length then return 0 end
+   if 15 > length then return false end
    A = P[14]
    if not (A==1500) then goto L4 end
-   do return 65535 end
+   do return true end
    ::L4::
-   do return 0 end
+   do return false end
    error("end of bpf")
 end
 ```

--- a/doc/ether-proto-1501.md
+++ b/doc/ether-proto-1501.md
@@ -16,12 +16,12 @@
 ```
 return function (P, length)
    local A = 0
-   if 14 > length then return 0 end
+   if 14 > length then return false end
    A = bit.bor(bit.lshift(P[12], 8), P[12+1])
    if not (A==1501) then goto L2 end
-   do return 65535 end
+   do return true end
    ::L2::
-   do return 0 end
+   do return false end
    error("end of bpf")
 end
 ```

--- a/doc/ether-proto-255.md
+++ b/doc/ether-proto-255.md
@@ -18,15 +18,15 @@
 ```
 return function (P, length)
    local A = 0
-   if 14 > length then return 0 end
+   if 14 > length then return false end
    A = bit.bor(bit.lshift(P[12], 8), P[12+1])
    if (runtime_u32(A)>1500) then goto L4 end
-   if 15 > length then return 0 end
+   if 15 > length then return false end
    A = P[14]
    if not (A==255) then goto L4 end
-   do return 65535 end
+   do return true end
    ::L4::
-   do return 0 end
+   do return false end
    error("end of bpf")
 end
 ```

--- a/doc/ether-proto-decnet.md
+++ b/doc/ether-proto-decnet.md
@@ -16,12 +16,12 @@
 ```
 return function (P, length)
    local A = 0
-   if 14 > length then return 0 end
+   if 14 > length then return false end
    A = bit.bor(bit.lshift(P[12], 8), P[12+1])
    if not (A==24579) then goto L2 end
-   do return 65535 end
+   do return true end
    ::L2::
-   do return 0 end
+   do return false end
    error("end of bpf")
 end
 ```

--- a/doc/host-127.0.0.1.md
+++ b/doc/host-127.0.0.1.md
@@ -26,13 +26,13 @@
 ```
 return function (P, length)
    local A = 0
-   if 14 > length then return 0 end
+   if 14 > length then return false end
    A = bit.bor(bit.lshift(P[12], 8), P[12+1])
    if not (A==2048) then goto L5 end
-   if 30 > length then return 0 end
+   if 30 > length then return false end
    A = bit.bor(bit.lshift(P[26], 24),bit.lshift(P[26+1], 16), bit.lshift(P[26+2], 8), P[26+3])
    if (A==2130706433) then goto L11 end
-   if 34 > length then return 0 end
+   if 34 > length then return false end
    A = bit.bor(bit.lshift(P[30], 24),bit.lshift(P[30+1], 16), bit.lshift(P[30+2], 8), P[30+3])
    if (A==2130706433) then goto L11 end
    goto L12
@@ -40,16 +40,16 @@ return function (P, length)
    if (A==2054) then goto L7 end
    if not (A==32821) then goto L12 end
    ::L7::
-   if 32 > length then return 0 end
+   if 32 > length then return false end
    A = bit.bor(bit.lshift(P[28], 24),bit.lshift(P[28+1], 16), bit.lshift(P[28+2], 8), P[28+3])
    if (A==2130706433) then goto L11 end
-   if 42 > length then return 0 end
+   if 42 > length then return false end
    A = bit.bor(bit.lshift(P[38], 24),bit.lshift(P[38+1], 16), bit.lshift(P[38+2], 8), P[38+3])
    if not (A==2130706433) then goto L12 end
    ::L11::
-   do return 65535 end
+   do return true end
    ::L12::
-   do return 0 end
+   do return false end
    error("end of bpf")
 end
 ```

--- a/doc/host-ipv6-localhost.md
+++ b/doc/host-ipv6-localhost.md
@@ -32,38 +32,38 @@
 ```
 return function (P, length)
    local A = 0
-   if 14 > length then return 0 end
+   if 14 > length then return false end
    A = bit.bor(bit.lshift(P[12], 8), P[12+1])
    if not (A==34525) then goto L18 end
-   if 26 > length then return 0 end
+   if 26 > length then return false end
    A = bit.bor(bit.lshift(P[22], 24),bit.lshift(P[22+1], 16), bit.lshift(P[22+2], 8), P[22+3])
    if not (A==0) then goto L9 end
-   if 30 > length then return 0 end
+   if 30 > length then return false end
    A = bit.bor(bit.lshift(P[26], 24),bit.lshift(P[26+1], 16), bit.lshift(P[26+2], 8), P[26+3])
    if not (A==0) then goto L9 end
-   if 34 > length then return 0 end
+   if 34 > length then return false end
    A = bit.bor(bit.lshift(P[30], 24),bit.lshift(P[30+1], 16), bit.lshift(P[30+2], 8), P[30+3])
    if not (A==0) then goto L9 end
-   if 38 > length then return 0 end
+   if 38 > length then return false end
    A = bit.bor(bit.lshift(P[34], 24),bit.lshift(P[34+1], 16), bit.lshift(P[34+2], 8), P[34+3])
    if (A==1) then goto L17 end
    ::L9::
-   if 42 > length then return 0 end
+   if 42 > length then return false end
    A = bit.bor(bit.lshift(P[38], 24),bit.lshift(P[38+1], 16), bit.lshift(P[38+2], 8), P[38+3])
    if not (A==0) then goto L18 end
-   if 46 > length then return 0 end
+   if 46 > length then return false end
    A = bit.bor(bit.lshift(P[42], 24),bit.lshift(P[42+1], 16), bit.lshift(P[42+2], 8), P[42+3])
    if not (A==0) then goto L18 end
-   if 50 > length then return 0 end
+   if 50 > length then return false end
    A = bit.bor(bit.lshift(P[46], 24),bit.lshift(P[46+1], 16), bit.lshift(P[46+2], 8), P[46+3])
    if not (A==0) then goto L18 end
-   if 54 > length then return 0 end
+   if 54 > length then return false end
    A = bit.bor(bit.lshift(P[50], 24),bit.lshift(P[50+1], 16), bit.lshift(P[50+2], 8), P[50+3])
    if not (A==1) then goto L18 end
    ::L17::
-   do return 65535 end
+   do return true end
    ::L18::
-   do return 0 end
+   do return false end
    error("end of bpf")
 end
 ```

--- a/doc/icmp-or-tcp-or-udp.md
+++ b/doc/icmp-or-tcp-or-udp.md
@@ -26,29 +26,29 @@
 ```
 return function (P, length)
    local A = 0
-   if 14 > length then return 0 end
+   if 14 > length then return false end
    A = bit.bor(bit.lshift(P[12], 8), P[12+1])
    if not (A==2048) then goto L4 end
-   if 24 > length then return 0 end
+   if 24 > length then return false end
    A = P[23]
    if (A==1) then goto L11 end
    if (A==6) then goto L11 end
    goto L10
    ::L4::
    if not (A==34525) then goto L12 end
-   if 21 > length then return 0 end
+   if 21 > length then return false end
    A = P[20]
    if (A==6) then goto L11 end
    if not (A==44) then goto L10 end
-   if 55 > length then return 0 end
+   if 55 > length then return false end
    A = P[54]
    if (A==6) then goto L11 end
    ::L10::
    if not (A==17) then goto L12 end
    ::L11::
-   do return 65535 end
+   do return true end
    ::L12::
-   do return 0 end
+   do return false end
    error("end of bpf")
 end
 ```

--- a/doc/icmp6.md
+++ b/doc/icmp6.md
@@ -21,20 +21,20 @@
 ```
 return function (P, length)
    local A = 0
-   if 14 > length then return 0 end
+   if 14 > length then return false end
    A = bit.bor(bit.lshift(P[12], 8), P[12+1])
    if not (A==34525) then goto L7 end
-   if 21 > length then return 0 end
+   if 21 > length then return false end
    A = P[20]
    if (A==58) then goto L6 end
    if not (A==44) then goto L7 end
-   if 55 > length then return 0 end
+   if 55 > length then return false end
    A = P[54]
    if not (A==58) then goto L7 end
    ::L6::
-   do return 65535 end
+   do return true end
    ::L7::
-   do return 0 end
+   do return false end
    error("end of bpf")
 end
 ```

--- a/doc/ip-multicast.md
+++ b/doc/ip-multicast.md
@@ -18,15 +18,15 @@
 ```
 return function (P, length)
    local A = 0
-   if 14 > length then return 0 end
+   if 14 > length then return false end
    A = bit.bor(bit.lshift(P[12], 8), P[12+1])
    if not (A==2048) then goto L4 end
-   if 31 > length then return 0 end
+   if 31 > length then return false end
    A = P[30]
    if not (runtime_u32(A)>=224) then goto L4 end
-   do return 65535 end
+   do return true end
    ::L4::
-   do return 0 end
+   do return false end
    error("end of bpf")
 end
 ```

--- a/doc/ip-proto-47.md
+++ b/doc/ip-proto-47.md
@@ -18,15 +18,15 @@
 ```
 return function (P, length)
    local A = 0
-   if 14 > length then return 0 end
+   if 14 > length then return false end
    A = bit.bor(bit.lshift(P[12], 8), P[12+1])
    if not (A==2048) then goto L4 end
-   if 24 > length then return 0 end
+   if 24 > length then return false end
    A = P[23]
    if not (A==47) then goto L4 end
-   do return 65535 end
+   do return true end
    ::L4::
-   do return 0 end
+   do return false end
    error("end of bpf")
 end
 ```

--- a/doc/ip-proto-ah.md
+++ b/doc/ip-proto-ah.md
@@ -18,15 +18,15 @@
 ```
 return function (P, length)
    local A = 0
-   if 14 > length then return 0 end
+   if 14 > length then return false end
    A = bit.bor(bit.lshift(P[12], 8), P[12+1])
    if not (A==2048) then goto L4 end
-   if 24 > length then return 0 end
+   if 24 > length then return false end
    A = P[23]
    if not (A==51) then goto L4 end
-   do return 65535 end
+   do return true end
    ::L4::
-   do return 0 end
+   do return false end
    error("end of bpf")
 end
 ```

--- a/doc/ip-proto-sctp.md
+++ b/doc/ip-proto-sctp.md
@@ -18,15 +18,15 @@
 ```
 return function (P, length)
    local A = 0
-   if 14 > length then return 0 end
+   if 14 > length then return false end
    A = bit.bor(bit.lshift(P[12], 8), P[12+1])
    if not (A==2048) then goto L4 end
-   if 24 > length then return 0 end
+   if 24 > length then return false end
    A = P[23]
    if not (A==132) then goto L4 end
-   do return 65535 end
+   do return true end
    ::L4::
-   do return 0 end
+   do return false end
    error("end of bpf")
 end
 ```

--- a/doc/ip6-multicast.md
+++ b/doc/ip6-multicast.md
@@ -18,15 +18,15 @@
 ```
 return function (P, length)
    local A = 0
-   if 14 > length then return 0 end
+   if 14 > length then return false end
    A = bit.bor(bit.lshift(P[12], 8), P[12+1])
    if not (A==34525) then goto L4 end
-   if 39 > length then return 0 end
+   if 39 > length then return false end
    A = P[38]
    if not (A==255) then goto L4 end
-   do return 65535 end
+   do return true end
    ::L4::
-   do return 0 end
+   do return false end
    error("end of bpf")
 end
 ```

--- a/doc/ip6-proto-47.md
+++ b/doc/ip6-proto-47.md
@@ -21,20 +21,20 @@
 ```
 return function (P, length)
    local A = 0
-   if 14 > length then return 0 end
+   if 14 > length then return false end
    A = bit.bor(bit.lshift(P[12], 8), P[12+1])
    if not (A==34525) then goto L7 end
-   if 21 > length then return 0 end
+   if 21 > length then return false end
    A = P[20]
    if (A==47) then goto L6 end
    if not (A==44) then goto L7 end
-   if 55 > length then return 0 end
+   if 55 > length then return false end
    A = P[54]
    if not (A==47) then goto L7 end
    ::L6::
-   do return 65535 end
+   do return true end
    ::L7::
-   do return 0 end
+   do return false end
    error("end of bpf")
 end
 ```

--- a/doc/ip6-proto-ah.md
+++ b/doc/ip6-proto-ah.md
@@ -21,20 +21,20 @@
 ```
 return function (P, length)
    local A = 0
-   if 14 > length then return 0 end
+   if 14 > length then return false end
    A = bit.bor(bit.lshift(P[12], 8), P[12+1])
    if not (A==34525) then goto L7 end
-   if 21 > length then return 0 end
+   if 21 > length then return false end
    A = P[20]
    if (A==51) then goto L6 end
    if not (A==44) then goto L7 end
-   if 55 > length then return 0 end
+   if 55 > length then return false end
    A = P[54]
    if not (A==51) then goto L7 end
    ::L6::
-   do return 65535 end
+   do return true end
    ::L7::
-   do return 0 end
+   do return false end
    error("end of bpf")
 end
 ```

--- a/doc/iso-proto-47.md
+++ b/doc/iso-proto-47.md
@@ -20,18 +20,18 @@
 ```
 return function (P, length)
    local A = 0
-   if 14 > length then return 0 end
+   if 14 > length then return false end
    A = bit.bor(bit.lshift(P[12], 8), P[12+1])
    if (runtime_u32(A)>1500) then goto L6 end
-   if 16 > length then return 0 end
+   if 16 > length then return false end
    A = bit.bor(bit.lshift(P[14], 8), P[14+1])
    if not (A==65278) then goto L6 end
-   if 18 > length then return 0 end
+   if 18 > length then return false end
    A = P[17]
    if not (A==47) then goto L6 end
-   do return 65535 end
+   do return true end
    ::L6::
-   do return 0 end
+   do return false end
    error("end of bpf")
 end
 ```

--- a/doc/iso-proto-clnp.md
+++ b/doc/iso-proto-clnp.md
@@ -20,18 +20,18 @@
 ```
 return function (P, length)
    local A = 0
-   if 14 > length then return 0 end
+   if 14 > length then return false end
    A = bit.bor(bit.lshift(P[12], 8), P[12+1])
    if (runtime_u32(A)>1500) then goto L6 end
-   if 16 > length then return 0 end
+   if 16 > length then return false end
    A = bit.bor(bit.lshift(P[14], 8), P[14+1])
    if not (A==65278) then goto L6 end
-   if 18 > length then return 0 end
+   if 18 > length then return false end
    A = P[17]
    if not (A==129) then goto L6 end
-   do return 65535 end
+   do return true end
    ::L6::
-   do return 0 end
+   do return false end
    error("end of bpf")
 end
 ```

--- a/doc/l1.md
+++ b/doc/l1.md
@@ -26,16 +26,16 @@
 ```
 return function (P, length)
    local A = 0
-   if 14 > length then return 0 end
+   if 14 > length then return false end
    A = bit.bor(bit.lshift(P[12], 8), P[12+1])
    if (runtime_u32(A)>1500) then goto L12 end
-   if 16 > length then return 0 end
+   if 16 > length then return false end
    A = bit.bor(bit.lshift(P[14], 8), P[14+1])
    if not (A==65278) then goto L12 end
-   if 18 > length then return 0 end
+   if 18 > length then return false end
    A = P[17]
    if not (A==131) then goto L12 end
-   if 22 > length then return 0 end
+   if 22 > length then return false end
    A = P[21]
    if (A==26) then goto L11 end
    if (A==24) then goto L11 end
@@ -43,9 +43,9 @@ return function (P, length)
    if (A==15) then goto L11 end
    if not (A==17) then goto L12 end
    ::L11::
-   do return 65535 end
+   do return true end
    ::L12::
-   do return 0 end
+   do return false end
    error("end of bpf")
 end
 ```

--- a/doc/net-127.0.0.0-8.md
+++ b/doc/net-127.0.0.0-8.md
@@ -30,14 +30,14 @@
 ```
 return function (P, length)
    local A = 0
-   if 14 > length then return 0 end
+   if 14 > length then return false end
    A = bit.bor(bit.lshift(P[12], 8), P[12+1])
    if not (A==2048) then goto L7 end
-   if 30 > length then return 0 end
+   if 30 > length then return false end
    A = bit.bor(bit.lshift(P[26], 24),bit.lshift(P[26+1], 16), bit.lshift(P[26+2], 8), P[26+3])
    A = bit.band(A, -16777216)
    if (A==2130706432) then goto L15 end
-   if 34 > length then return 0 end
+   if 34 > length then return false end
    A = bit.bor(bit.lshift(P[30], 24),bit.lshift(P[30+1], 16), bit.lshift(P[30+2], 8), P[30+3])
    A = bit.band(A, -16777216)
    if (A==2130706432) then goto L15 end
@@ -46,18 +46,18 @@ return function (P, length)
    if (A==2054) then goto L9 end
    if not (A==32821) then goto L16 end
    ::L9::
-   if 32 > length then return 0 end
+   if 32 > length then return false end
    A = bit.bor(bit.lshift(P[28], 24),bit.lshift(P[28+1], 16), bit.lshift(P[28+2], 8), P[28+3])
    A = bit.band(A, -16777216)
    if (A==2130706432) then goto L15 end
-   if 42 > length then return 0 end
+   if 42 > length then return false end
    A = bit.bor(bit.lshift(P[38], 24),bit.lshift(P[38+1], 16), bit.lshift(P[38+2], 8), P[38+3])
    A = bit.band(A, -16777216)
    if not (A==2130706432) then goto L16 end
    ::L15::
-   do return 65535 end
+   do return true end
    ::L16::
-   do return 0 end
+   do return false end
    error("end of bpf")
 end
 ```

--- a/doc/net-ipv6-0-mask-16.md
+++ b/doc/net-ipv6-0-mask-16.md
@@ -20,19 +20,19 @@
 ```
 return function (P, length)
    local A = 0
-   if 14 > length then return 0 end
+   if 14 > length then return false end
    A = bit.bor(bit.lshift(P[12], 8), P[12+1])
    if not (A==34525) then goto L6 end
-   if 26 > length then return 0 end
+   if 26 > length then return false end
    A = bit.bor(bit.lshift(P[22], 24),bit.lshift(P[22+1], 16), bit.lshift(P[22+2], 8), P[22+3])
    if (bit.band(A, -65536)==0) then goto L5 end
-   if 42 > length then return 0 end
+   if 42 > length then return false end
    A = bit.bor(bit.lshift(P[38], 24),bit.lshift(P[38+1], 16), bit.lshift(P[38+2], 8), P[38+3])
    if not (bit.band(A, -65536)==0) then goto L6 end
    ::L5::
-   do return 65535 end
+   do return true end
    ::L6::
-   do return 0 end
+   do return false end
    error("end of bpf")
 end
 ```

--- a/doc/net-ipv6-ee.cc.9954.0-mask-111.md
+++ b/doc/net-ipv6-ee.cc.9954.0-mask-111.md
@@ -34,40 +34,40 @@
 ```
 return function (P, length)
    local A = 0
-   if 14 > length then return 0 end
+   if 14 > length then return false end
    A = bit.bor(bit.lshift(P[12], 8), P[12+1])
    if not (A==34525) then goto L20 end
-   if 26 > length then return 0 end
+   if 26 > length then return false end
    A = bit.bor(bit.lshift(P[22], 24),bit.lshift(P[22+1], 16), bit.lshift(P[22+2], 8), P[22+3])
    if not (A==15597772) then goto L10 end
-   if 30 > length then return 0 end
+   if 30 > length then return false end
    A = bit.bor(bit.lshift(P[26], 24),bit.lshift(P[26+1], 16), bit.lshift(P[26+2], 8), P[26+3])
    if not (A==0) then goto L10 end
-   if 34 > length then return 0 end
+   if 34 > length then return false end
    A = bit.bor(bit.lshift(P[30], 24),bit.lshift(P[30+1], 16), bit.lshift(P[30+2], 8), P[30+3])
    if not (A==0) then goto L10 end
-   if 38 > length then return 0 end
+   if 38 > length then return false end
    A = bit.bor(bit.lshift(P[34], 24),bit.lshift(P[34+1], 16), bit.lshift(P[34+2], 8), P[34+3])
    A = bit.band(A, -131072)
    if (A==-1722548224) then goto L19 end
    ::L10::
-   if 42 > length then return 0 end
+   if 42 > length then return false end
    A = bit.bor(bit.lshift(P[38], 24),bit.lshift(P[38+1], 16), bit.lshift(P[38+2], 8), P[38+3])
    if not (A==15597772) then goto L20 end
-   if 46 > length then return 0 end
+   if 46 > length then return false end
    A = bit.bor(bit.lshift(P[42], 24),bit.lshift(P[42+1], 16), bit.lshift(P[42+2], 8), P[42+3])
    if not (A==0) then goto L20 end
-   if 50 > length then return 0 end
+   if 50 > length then return false end
    A = bit.bor(bit.lshift(P[46], 24),bit.lshift(P[46+1], 16), bit.lshift(P[46+2], 8), P[46+3])
    if not (A==0) then goto L20 end
-   if 54 > length then return 0 end
+   if 54 > length then return false end
    A = bit.bor(bit.lshift(P[50], 24),bit.lshift(P[50+1], 16), bit.lshift(P[50+2], 8), P[50+3])
    A = bit.band(A, -131072)
    if not (A==-1722548224) then goto L20 end
    ::L19::
-   do return 65535 end
+   do return true end
    ::L20::
-   do return 0 end
+   do return false end
    error("end of bpf")
 end
 ```

--- a/doc/portrange-0-6000.md
+++ b/doc/portrange-0-6000.md
@@ -41,53 +41,53 @@ return function (P, length)
    local A = 0
    local X = 0
    local T = 0
-   if 14 > length then return 0 end
+   if 14 > length then return false end
    A = bit.bor(bit.lshift(P[12], 8), P[12+1])
    if not (A==34525) then goto L10 end
-   if 21 > length then return 0 end
+   if 21 > length then return false end
    A = P[20]
    if (A==132) then goto L5 end
    if (A==6) then goto L5 end
    if not (A==17) then goto L25 end
    ::L5::
-   if 56 > length then return 0 end
+   if 56 > length then return false end
    A = bit.bor(bit.lshift(P[54], 8), P[54+1])
    if not (runtime_u32(A)>=0) then goto L8 end
    if not (runtime_u32(A)>6000) then goto L24 end
    ::L8::
-   if 58 > length then return 0 end
+   if 58 > length then return false end
    A = bit.bor(bit.lshift(P[56], 8), P[56+1])
    if (runtime_u32(A)>=0) then goto L23 end
    goto L25
    ::L10::
    if not (A==2048) then goto L25 end
-   if 24 > length then return 0 end
+   if 24 > length then return false end
    A = P[23]
    if (A==132) then goto L15 end
    if (A==6) then goto L15 end
    if not (A==17) then goto L25 end
    ::L15::
-   if 22 > length then return 0 end
+   if 22 > length then return false end
    A = bit.bor(bit.lshift(P[20], 8), P[20+1])
    if not (bit.band(A, 8191)==0) then goto L25 end
-   if 14 >= length then return 0 end
+   if 14 >= length then return false end
    X = bit.lshift(bit.band(P[14], 15), 2)
    T = bit.tobit((X+14))
-   if T < 0 or T + 2 > length then return 0 end
+   if T < 0 or T + 2 > length then return false end
    A = bit.bor(bit.lshift(P[T], 8), P[T+1])
    if not (runtime_u32(A)>=0) then goto L21 end
    if not (runtime_u32(A)>6000) then goto L24 end
    ::L21::
    T = bit.tobit((X+16))
-   if T < 0 or T + 2 > length then return 0 end
+   if T < 0 or T + 2 > length then return false end
    A = bit.bor(bit.lshift(P[T], 8), P[T+1])
    if not (runtime_u32(A)>=0) then goto L25 end
    ::L23::
    if (runtime_u32(A)>6000) then goto L25 end
    ::L24::
-   do return 65535 end
+   do return true end
    ::L25::
-   do return 0 end
+   do return false end
    error("end of bpf")
 end
 ```

--- a/doc/proto-47.md
+++ b/doc/proto-47.md
@@ -24,26 +24,26 @@
 ```
 return function (P, length)
    local A = 0
-   if 14 > length then return 0 end
+   if 14 > length then return false end
    A = bit.bor(bit.lshift(P[12], 8), P[12+1])
    if not (A==2048) then goto L3 end
-   if 24 > length then return 0 end
+   if 24 > length then return false end
    A = P[23]
    if (A==47) then goto L9 end
    goto L10
    ::L3::
    if not (A==34525) then goto L10 end
-   if 21 > length then return 0 end
+   if 21 > length then return false end
    A = P[20]
    if (A==47) then goto L9 end
    if not (A==44) then goto L10 end
-   if 55 > length then return 0 end
+   if 55 > length then return false end
    A = P[54]
    if not (A==47) then goto L10 end
    ::L9::
-   do return 65535 end
+   do return true end
    ::L10::
-   do return 0 end
+   do return false end
    error("end of bpf")
 end
 ```

--- a/doc/src-host-192.68.1.1-and-less-100.md
+++ b/doc/src-host-192.68.1.1-and-less-100.md
@@ -24,10 +24,10 @@
 ```
 return function (P, length)
    local A = 0
-   if 14 > length then return 0 end
+   if 14 > length then return false end
    A = bit.bor(bit.lshift(P[12], 8), P[12+1])
    if not (A==2048) then goto L3 end
-   if 30 > length then return 0 end
+   if 30 > length then return false end
    A = bit.bor(bit.lshift(P[26], 24),bit.lshift(P[26+1], 16), bit.lshift(P[26+2], 8), P[26+3])
    if (A==-1069285119) then goto L7 end
    goto L10
@@ -35,15 +35,15 @@ return function (P, length)
    if (A==2054) then goto L5 end
    if not (A==32821) then goto L10 end
    ::L5::
-   if 32 > length then return 0 end
+   if 32 > length then return false end
    A = bit.bor(bit.lshift(P[28], 24),bit.lshift(P[28+1], 16), bit.lshift(P[28+2], 8), P[28+3])
    if not (A==-1069285119) then goto L10 end
    ::L7::
    A = bit.tobit(length)
    if (runtime_u32(A)>100) then goto L10 end
-   do return 65535 end
+   do return true end
    ::L10::
-   do return 0 end
+   do return false end
    error("end of bpf")
 end
 ```

--- a/doc/src-net-ffff.ffff.eeee.eeee.0.0.0.0-72.md
+++ b/doc/src-net-ffff.ffff.eeee.eeee.0.0.0.0-72.md
@@ -22,21 +22,21 @@
 ```
 return function (P, length)
    local A = 0
-   if 14 > length then return 0 end
+   if 14 > length then return false end
    A = bit.bor(bit.lshift(P[12], 8), P[12+1])
    if not (A==34525) then goto L8 end
-   if 26 > length then return 0 end
+   if 26 > length then return false end
    A = bit.bor(bit.lshift(P[22], 24),bit.lshift(P[22+1], 16), bit.lshift(P[22+2], 8), P[22+3])
    if not (A==-1) then goto L8 end
-   if 30 > length then return 0 end
+   if 30 > length then return false end
    A = bit.bor(bit.lshift(P[26], 24),bit.lshift(P[26+1], 16), bit.lshift(P[26+2], 8), P[26+3])
    if not (A==-286331154) then goto L8 end
-   if 34 > length then return 0 end
+   if 34 > length then return false end
    A = bit.bor(bit.lshift(P[30], 24),bit.lshift(P[30+1], 16), bit.lshift(P[30+2], 8), P[30+3])
    if not (bit.band(A, -16777216)==0) then goto L8 end
-   do return 65535 end
+   do return true end
    ::L8::
-   do return 0 end
+   do return false end
    error("end of bpf")
 end
 ```

--- a/doc/src-net-ffff.ffff.eeee.eeee.1.0.0.0-82.md
+++ b/doc/src-net-ffff.ffff.eeee.eeee.1.0.0.0-82.md
@@ -23,22 +23,22 @@
 ```
 return function (P, length)
    local A = 0
-   if 14 > length then return 0 end
+   if 14 > length then return false end
    A = bit.bor(bit.lshift(P[12], 8), P[12+1])
    if not (A==34525) then goto L9 end
-   if 26 > length then return 0 end
+   if 26 > length then return false end
    A = bit.bor(bit.lshift(P[22], 24),bit.lshift(P[22+1], 16), bit.lshift(P[22+2], 8), P[22+3])
    if not (A==-1) then goto L9 end
-   if 30 > length then return 0 end
+   if 30 > length then return false end
    A = bit.bor(bit.lshift(P[26], 24),bit.lshift(P[26+1], 16), bit.lshift(P[26+2], 8), P[26+3])
    if not (A==-286331154) then goto L9 end
-   if 34 > length then return 0 end
+   if 34 > length then return false end
    A = bit.bor(bit.lshift(P[30], 24),bit.lshift(P[30+1], 16), bit.lshift(P[30+2], 8), P[30+3])
    A = bit.band(A, -16384)
    if not (A==65536) then goto L9 end
-   do return 65535 end
+   do return true end
    ::L9::
-   do return 0 end
+   do return false end
    error("end of bpf")
 end
 ```

--- a/doc/src-port-80.md
+++ b/doc/src-port-80.md
@@ -34,40 +34,40 @@ return function (P, length)
    local A = 0
    local X = 0
    local T = 0
-   if 14 > length then return 0 end
+   if 14 > length then return false end
    A = bit.bor(bit.lshift(P[12], 8), P[12+1])
    if not (A==34525) then goto L7 end
-   if 21 > length then return 0 end
+   if 21 > length then return false end
    A = P[20]
    if (A==132) then goto L5 end
    if (A==6) then goto L5 end
    if not (A==17) then goto L18 end
    ::L5::
-   if 56 > length then return 0 end
+   if 56 > length then return false end
    A = bit.bor(bit.lshift(P[54], 8), P[54+1])
    if (A==80) then goto L17 end
    goto L18
    ::L7::
    if not (A==2048) then goto L18 end
-   if 24 > length then return 0 end
+   if 24 > length then return false end
    A = P[23]
    if (A==132) then goto L12 end
    if (A==6) then goto L12 end
    if not (A==17) then goto L18 end
    ::L12::
-   if 22 > length then return 0 end
+   if 22 > length then return false end
    A = bit.bor(bit.lshift(P[20], 8), P[20+1])
    if not (bit.band(A, 8191)==0) then goto L18 end
-   if 14 >= length then return 0 end
+   if 14 >= length then return false end
    X = bit.lshift(bit.band(P[14], 15), 2)
    T = bit.tobit((X+14))
-   if T < 0 or T + 2 > length then return 0 end
+   if T < 0 or T + 2 > length then return false end
    A = bit.bor(bit.lshift(P[T], 8), P[T+1])
    if not (A==80) then goto L18 end
    ::L17::
-   do return 65535 end
+   do return true end
    ::L18::
-   do return 0 end
+   do return false end
    error("end of bpf")
 end
 ```

--- a/doc/tcp-port-80.md
+++ b/doc/tcp-port-80.md
@@ -34,41 +34,41 @@ return function (P, length)
    local A = 0
    local X = 0
    local T = 0
-   if 14 > length then return 0 end
+   if 14 > length then return false end
    A = bit.bor(bit.lshift(P[12], 8), P[12+1])
    if not (A==34525) then goto L7 end
-   if 21 > length then return 0 end
+   if 21 > length then return false end
    A = P[20]
    if not (A==6) then goto L18 end
-   if 56 > length then return 0 end
+   if 56 > length then return false end
    A = bit.bor(bit.lshift(P[54], 8), P[54+1])
    if (A==80) then goto L17 end
-   if 58 > length then return 0 end
+   if 58 > length then return false end
    A = bit.bor(bit.lshift(P[56], 8), P[56+1])
    if (A==80) then goto L17 end
    goto L18
    ::L7::
    if not (A==2048) then goto L18 end
-   if 24 > length then return 0 end
+   if 24 > length then return false end
    A = P[23]
    if not (A==6) then goto L18 end
-   if 22 > length then return 0 end
+   if 22 > length then return false end
    A = bit.bor(bit.lshift(P[20], 8), P[20+1])
    if not (bit.band(A, 8191)==0) then goto L18 end
-   if 14 >= length then return 0 end
+   if 14 >= length then return false end
    X = bit.lshift(bit.band(P[14], 15), 2)
    T = bit.tobit((X+14))
-   if T < 0 or T + 2 > length then return 0 end
+   if T < 0 or T + 2 > length then return false end
    A = bit.bor(bit.lshift(P[T], 8), P[T+1])
    if (A==80) then goto L17 end
    T = bit.tobit((X+16))
-   if T < 0 or T + 2 > length then return 0 end
+   if T < 0 or T + 2 > length then return false end
    A = bit.bor(bit.lshift(P[T], 8), P[T+1])
    if not (A==80) then goto L18 end
    ::L17::
-   do return 65535 end
+   do return true end
    ::L18::
-   do return 0 end
+   do return false end
    error("end of bpf")
 end
 ```

--- a/src/pf.lua
+++ b/src/pf.lua
@@ -26,8 +26,7 @@ function compile_filter(filter_str, opts)
    elseif opts.bpf then
       local bytecode = libpcap.compile(filter_str, dlt)
       if opts.source then return bpf.compile_lua(bytecode) end
-      local bpf_prog = bpf.compile(bytecode)
-      return function(P, len) return bpf_prog(P, len) ~= 0 end
+      return bpf.compile(bytecode)
    else
       local expr = parse.parse(filter_str)
       expr = expand.expand(expr, dlt)


### PR DESCRIPTION
There's an inconsistency between the value returned in the BPF pipeline if the function is compiled directly or if it's printed as source code and later loaded. In the first case, the function returns a boolean:

```lua
local bpf_prog = bpf.compile(bytecode)
return function(P, len) return bpf_prog(P, len) ~= 0 end
```
In the second case, the function returns an integer. The user of this function must remember to compared the result of this function against zero.

```lua
   ::L9::
   do return 65535 end
   ::L10::
   do return 0 end
   error("end of bpf")
```

This creates an inconsistency while running ```pflua-match```, as it doesn't make a difference between whether the function was compiled or was loaded from a file. For instance:

```bash
tools $ ./pflua-match --bpf v4.pcap "esp"
Matched 0/43 packets in 823662 iterations: v4.pcap (35.417466 MPPS).
```

```
tools $ ./pflua-compile --bpf-lua "esp" > esp-bpf.lua
tools $ ./pflua-match v4.pcap "esp-bpf.lua" 
Matched 43/43 packets in 767135 iterations: v4.pcap (32.986805 MPPS).
```

One solution is to tweak ```pflua-match``` and check whether the result returned is of type integer, and in that case compare against zero. Another solution, is to modify the returned function compiled by the BPF pipeline, so it returns true or false directly. I prefer the second solution, so it's consistent with the Lua pipeline and users don't have to remember this fact.