### PR TITLE
Keyword elision not implemented with packet access: igmp, pim, igrp, vrrp

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -36,7 +36,12 @@ EXAMPLES = \
 	decnet-host-10.15.md \
 	l1.md \
 	icmp6.md \
-	sctp.md
+	sctp.md \
+	packet-access-igmp.md \
+	packet-access-pim.md \
+	packet-access-igrp.md \
+	packet-access-vrrp.md \
+	packet-access-sctp.md
 
 PFLUA = \
 	../src/pf.lua \
@@ -161,3 +166,18 @@ icmp6.md: $(PFLUA)
 
 sctp.md: $(PFLUA)
 	../tools/dump-markdown "sctp" > $@.tmp && mv $@.tmp $@
+
+packet-access-igmp.md: $(PFLUA)
+	../tools/dump-markdown "igmp[8] < 8" > $@.tmp && mv $@.tmp $@
+
+packet-access-pim.md: $(PFLUA)
+	../tools/dump-markdown "pim[8] < 8" > $@.tmp && mv $@.tmp $@
+
+packet-access-igrp.md : $(PFLUA)
+	../tools/dump-markdown "igrp[8] < 8" > $@.tmp && mv $@.tmp $@
+
+packet-access-vrrp.md: $(PFLUA)
+	../tools/dump-markdown "vrrp[8] < 8" > $@.tmp && mv $@.tmp $@
+
+packet-access-sctp.md: $(PFLUA)
+	../tools/dump-markdown "sctp[8] < 8" > $@.tmp && mv $@.tmp $@

--- a/doc/packet-access-igmp.md
+++ b/doc/packet-access-igmp.md
@@ -1,0 +1,68 @@
+# igmp[8] < 8
+
+
+## BPF
+
+```
+000: A = P[12:2]
+001: if (A == 2048) goto 2 else goto 10
+002: A = P[23:1]
+003: if (A == 2) goto 4 else goto 10
+004: A = P[20:2]
+005: if (A & 8191 != 0) goto 10 else goto 6
+006: X = (P[14:1] & 0xF) << 2
+007: A = P[X+22:1]
+008: if (A >= 8) goto 10 else goto 9
+009: return 65535
+010: return 0
+```
+
+
+## BPF cross-compiled to Lua
+
+```
+return function (P, length)
+   local A = 0
+   local X = 0
+   local T = 0
+   if 14 > length then return false end
+   A = bit.bor(bit.lshift(P[12], 8), P[12+1])
+   if not (A==2048) then goto L9 end
+   if 24 > length then return false end
+   A = P[23]
+   if not (A==2) then goto L9 end
+   if 22 > length then return false end
+   A = bit.bor(bit.lshift(P[20], 8), P[20+1])
+   if not (bit.band(A, 8191)==0) then goto L9 end
+   if 14 >= length then return false end
+   X = bit.lshift(bit.band(P[14], 15), 2)
+   T = bit.tobit((X+22))
+   if T < 0 or T + 1 > length then return false end
+   A = P[T]
+   if (runtime_u32(A)>=8) then goto L9 end
+   do return true end
+   ::L9::
+   do return false end
+   error("end of bpf")
+end
+```
+
+
+## Direct pflang compilation
+
+```
+local lshift = require("bit").lshift
+local band = require("bit").band
+local cast = require("ffi").cast
+return function(P,length)
+   if length < 42 then return false end
+   if cast("uint16_t*", P+12)[0] ~= 8 then return false end
+   if P[23] ~= 2 then return false end
+   if band(cast("uint16_t*", P+20)[0],65311) ~= 0 then return false end
+   local var7 = lshift(band(P[14],15),2)
+   if (var7 + 23) > length then return false end
+   return P[(var7 + 22)] < 8
+end
+
+```
+

--- a/doc/packet-access-igrp.md
+++ b/doc/packet-access-igrp.md
@@ -1,0 +1,68 @@
+# igrp[8] < 8
+
+
+## BPF
+
+```
+000: A = P[12:2]
+001: if (A == 2048) goto 2 else goto 10
+002: A = P[23:1]
+003: if (A == 9) goto 4 else goto 10
+004: A = P[20:2]
+005: if (A & 8191 != 0) goto 10 else goto 6
+006: X = (P[14:1] & 0xF) << 2
+007: A = P[X+22:1]
+008: if (A >= 8) goto 10 else goto 9
+009: return 65535
+010: return 0
+```
+
+
+## BPF cross-compiled to Lua
+
+```
+return function (P, length)
+   local A = 0
+   local X = 0
+   local T = 0
+   if 14 > length then return false end
+   A = bit.bor(bit.lshift(P[12], 8), P[12+1])
+   if not (A==2048) then goto L9 end
+   if 24 > length then return false end
+   A = P[23]
+   if not (A==9) then goto L9 end
+   if 22 > length then return false end
+   A = bit.bor(bit.lshift(P[20], 8), P[20+1])
+   if not (bit.band(A, 8191)==0) then goto L9 end
+   if 14 >= length then return false end
+   X = bit.lshift(bit.band(P[14], 15), 2)
+   T = bit.tobit((X+22))
+   if T < 0 or T + 1 > length then return false end
+   A = P[T]
+   if (runtime_u32(A)>=8) then goto L9 end
+   do return true end
+   ::L9::
+   do return false end
+   error("end of bpf")
+end
+```
+
+
+## Direct pflang compilation
+
+```
+local lshift = require("bit").lshift
+local band = require("bit").band
+local cast = require("ffi").cast
+return function(P,length)
+   if length < 42 then return false end
+   if cast("uint16_t*", P+12)[0] ~= 8 then return false end
+   if P[23] ~= 9 then return false end
+   if band(cast("uint16_t*", P+20)[0],65311) ~= 0 then return false end
+   local var7 = lshift(band(P[14],15),2)
+   if (var7 + 23) > length then return false end
+   return P[(var7 + 22)] < 8
+end
+
+```
+

--- a/doc/packet-access-pim.md
+++ b/doc/packet-access-pim.md
@@ -1,0 +1,68 @@
+# pim[8] < 8
+
+
+## BPF
+
+```
+000: A = P[12:2]
+001: if (A == 2048) goto 2 else goto 10
+002: A = P[23:1]
+003: if (A == 103) goto 4 else goto 10
+004: A = P[20:2]
+005: if (A & 8191 != 0) goto 10 else goto 6
+006: X = (P[14:1] & 0xF) << 2
+007: A = P[X+22:1]
+008: if (A >= 8) goto 10 else goto 9
+009: return 65535
+010: return 0
+```
+
+
+## BPF cross-compiled to Lua
+
+```
+return function (P, length)
+   local A = 0
+   local X = 0
+   local T = 0
+   if 14 > length then return false end
+   A = bit.bor(bit.lshift(P[12], 8), P[12+1])
+   if not (A==2048) then goto L9 end
+   if 24 > length then return false end
+   A = P[23]
+   if not (A==103) then goto L9 end
+   if 22 > length then return false end
+   A = bit.bor(bit.lshift(P[20], 8), P[20+1])
+   if not (bit.band(A, 8191)==0) then goto L9 end
+   if 14 >= length then return false end
+   X = bit.lshift(bit.band(P[14], 15), 2)
+   T = bit.tobit((X+22))
+   if T < 0 or T + 1 > length then return false end
+   A = P[T]
+   if (runtime_u32(A)>=8) then goto L9 end
+   do return true end
+   ::L9::
+   do return false end
+   error("end of bpf")
+end
+```
+
+
+## Direct pflang compilation
+
+```
+local lshift = require("bit").lshift
+local band = require("bit").band
+local cast = require("ffi").cast
+return function(P,length)
+   if length < 42 then return false end
+   if cast("uint16_t*", P+12)[0] ~= 8 then return false end
+   if P[23] ~= 103 then return false end
+   if band(cast("uint16_t*", P+20)[0],65311) ~= 0 then return false end
+   local var7 = lshift(band(P[14],15),2)
+   if (var7 + 23) > length then return false end
+   return P[(var7 + 22)] < 8
+end
+
+```
+

--- a/doc/packet-access-sctp.md
+++ b/doc/packet-access-sctp.md
@@ -1,0 +1,68 @@
+# sctp[8] < 8
+
+
+## BPF
+
+```
+000: A = P[12:2]
+001: if (A == 2048) goto 2 else goto 10
+002: A = P[23:1]
+003: if (A == 132) goto 4 else goto 10
+004: A = P[20:2]
+005: if (A & 8191 != 0) goto 10 else goto 6
+006: X = (P[14:1] & 0xF) << 2
+007: A = P[X+22:1]
+008: if (A >= 8) goto 10 else goto 9
+009: return 65535
+010: return 0
+```
+
+
+## BPF cross-compiled to Lua
+
+```
+return function (P, length)
+   local A = 0
+   local X = 0
+   local T = 0
+   if 14 > length then return false end
+   A = bit.bor(bit.lshift(P[12], 8), P[12+1])
+   if not (A==2048) then goto L9 end
+   if 24 > length then return false end
+   A = P[23]
+   if not (A==132) then goto L9 end
+   if 22 > length then return false end
+   A = bit.bor(bit.lshift(P[20], 8), P[20+1])
+   if not (bit.band(A, 8191)==0) then goto L9 end
+   if 14 >= length then return false end
+   X = bit.lshift(bit.band(P[14], 15), 2)
+   T = bit.tobit((X+22))
+   if T < 0 or T + 1 > length then return false end
+   A = P[T]
+   if (runtime_u32(A)>=8) then goto L9 end
+   do return true end
+   ::L9::
+   do return false end
+   error("end of bpf")
+end
+```
+
+
+## Direct pflang compilation
+
+```
+local lshift = require("bit").lshift
+local band = require("bit").band
+local cast = require("ffi").cast
+return function(P,length)
+   if length < 42 then return false end
+   if cast("uint16_t*", P+12)[0] ~= 8 then return false end
+   if P[23] ~= 132 then return false end
+   if band(cast("uint16_t*", P+20)[0],65311) ~= 0 then return false end
+   local var7 = lshift(band(P[14],15),2)
+   if (var7 + 23) > length then return false end
+   return P[(var7 + 22)] < 8
+end
+
+```
+

--- a/doc/packet-access-vrrp.md
+++ b/doc/packet-access-vrrp.md
@@ -1,0 +1,68 @@
+# vrrp[8] < 8
+
+
+## BPF
+
+```
+000: A = P[12:2]
+001: if (A == 2048) goto 2 else goto 10
+002: A = P[23:1]
+003: if (A == 112) goto 4 else goto 10
+004: A = P[20:2]
+005: if (A & 8191 != 0) goto 10 else goto 6
+006: X = (P[14:1] & 0xF) << 2
+007: A = P[X+22:1]
+008: if (A >= 8) goto 10 else goto 9
+009: return 65535
+010: return 0
+```
+
+
+## BPF cross-compiled to Lua
+
+```
+return function (P, length)
+   local A = 0
+   local X = 0
+   local T = 0
+   if 14 > length then return false end
+   A = bit.bor(bit.lshift(P[12], 8), P[12+1])
+   if not (A==2048) then goto L9 end
+   if 24 > length then return false end
+   A = P[23]
+   if not (A==112) then goto L9 end
+   if 22 > length then return false end
+   A = bit.bor(bit.lshift(P[20], 8), P[20+1])
+   if not (bit.band(A, 8191)==0) then goto L9 end
+   if 14 >= length then return false end
+   X = bit.lshift(bit.band(P[14], 15), 2)
+   T = bit.tobit((X+22))
+   if T < 0 or T + 1 > length then return false end
+   A = P[T]
+   if (runtime_u32(A)>=8) then goto L9 end
+   do return true end
+   ::L9::
+   do return false end
+   error("end of bpf")
+end
+```
+
+
+## Direct pflang compilation
+
+```
+local lshift = require("bit").lshift
+local band = require("bit").band
+local cast = require("ffi").cast
+return function(P,length)
+   if length < 42 then return false end
+   if cast("uint16_t*", P+12)[0] ~= 8 then return false end
+   if P[23] ~= 112 then return false end
+   if band(cast("uint16_t*", P+20)[0],65311) ~= 0 then return false end
+   local var7 = lshift(band(P[14],15),2)
+   if (var7 + 23) > length then return false end
+   return P[(var7 + 22)] < 8
+end
+
+```
+

--- a/src/pf/expand.lua
+++ b/src/pf/expand.lua
@@ -84,7 +84,12 @@ local PROTO_VRRP = 112        -- 0x70
 local ip_min_payloads = {
    [PROTO_ICMP] = 8,
    [PROTO_UDP] = 8,
-   [PROTO_TCP] = 20
+   [PROTO_TCP] = 20,
+   [PROTO_IGMP] = 8,
+   [PROTO_IGRP] = 8,
+   [PROTO_PIM] = 4,
+   [PROTO_SCTP] = 12,
+   [PROTO_VRRP] = 8
 }
 
 -- ISO protocols
@@ -1039,6 +1044,16 @@ local function expand_offset(level, dlt)
       return ipv4_payload_offset(PROTO_UDP)
    elseif level == 'tcp' then
       return ipv4_payload_offset(PROTO_TCP)
+   elseif level == 'igmp' then
+      return ipv4_payload_offset(PROTO_IGMP)
+   elseif level == 'igrp' then
+      return ipv4_payload_offset(PROTO_IGRP)
+   elseif level == 'pim' then
+      return ipv4_payload_offset(PROTO_PIM)
+   elseif level == 'sctp' then
+      return ipv4_payload_offset(PROTO_SCTP)
+   elseif level == 'vrrp' then
+      return ipv4_payload_offset(PROTO_VRRP)
    end
    error('invalid level '..level)
 end

--- a/src/pf/parse.lua
+++ b/src/pf/parse.lua
@@ -293,7 +293,8 @@ end
 
 local addressables = set(
    'arp', 'rarp', 'wlan', 'ether', 'fddi', 'tr', 'ppp',
-   'slip', 'link', 'radio', 'ip', 'ip6', 'tcp', 'udp', 'icmp'
+   'slip', 'link', 'radio', 'ip', 'ip6', 'tcp', 'udp', 'icmp',
+   'igmp', 'pim', 'igrp', 'vrrp', 'sctp'
 )
 
 local function nullary()
@@ -1050,6 +1051,11 @@ function selftest ()
              { 'src_net', { 'ipv4/mask', { 'ipv4', 192, 168, 1, 0 }, { 'ipv4', 255, 255, 255, 0 } } })
    parse_test("less 100", {"less", 100})
    parse_test("greater 50 + 50", {"greater", {"+", 50, 50}})
+   parse_test("sctp[8] < 8", {'<', { '[sctp]', 8, 1 }, 8})
+   parse_test("igmp[8] < 8", {'<', { '[igmp]', 8, 1 }, 8})
+   parse_test("igrp[8] < 8", {'<', { '[igrp]', 8, 1 }, 8})
+   parse_test("pim[8] < 8", {'<', { '[pim]', 8, 1 }, 8})
+   parse_test("vrrp[8] < 8", {'<', { '[vrrp]', 8, 1 }, 8})
    parse_test("icmp[icmptype] != icmp-echo and icmp[icmptype] != icmp-echoreply",
               { "and",
                 { "!=", { "[icmp]", 0, 1 }, 8 },


### PR DESCRIPTION
A filter of "igmp" compiles with pflua, but not a filter of "igmp[8] < 7" or anything else using the [] syntax, unlike tcpdump.

```
% ./pflua-match ../tests/data/wingolog.pcap "igmp"   
Matched 0/19589 packets in 7934 iterations: ../tests/data/wingolog.pcap (155.411511 MPPS).
```
```
% ./pflua-match ../tests/data/wingolog.pcap "igmp[8] < 7"
luajit: ../src/pf/parse.lua:290: 
Error: In expression "igmp[8] < 7"
                           ^
keyword elision not implemented [

stack traceback:
        [C]: in function 'primitive_error'
        ../src/pf/parse.lua:290: in function 'error'
        ../src/pf/parse.lua:838: in function 'parse_primitive_or_arithmetic'
        ../src/pf/parse.lua:859: in function 'parse_logical_or_arithmetic'
        ../src/pf/parse.lua:891: in function 'parse_logical'
        ../src/pf/parse.lua:884: in function 'parse_logical_or_arithmetic'
        ../src/pf/parse.lua:891: in function 'parse_logical'
        ../src/pf/parse.lua:899: in function 'parse'
        ../src/pf.lua:32: in function 'get_predicate'
        ./pflua-match:58: in function 'main'
        ./pflua-match:84: in main chunk
        [C]: at 0x00404bc0
```
```
% tcpdump -d "igmp[8] <7" 
(000) ldh      [12]
(001) jeq      #0x800           jt 2    jf 10
(002) ldb      [23]
(003) jeq      #0x2             jt 4    jf 10
(004) ldh      [20]
(005) jset     #0x1fff          jt 10   jf 6
(006) ldxb     4*([14]&0xf)
(007) ldb      [x + 22]
(008) jge      #0x7             jt 10   jf 9
(009) ret      #65535
(010) ret      #0
```