### PR TITLE
Use Snabb's GitHub mirror of the LuaJIT repository

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "deps/luajit"]
 	path = deps/luajit
-	url = http://luajit.org/git/luajit-2.0.git
+	url = http://github.com/SnabbCo/luajit.git
         ignore = dirty


### PR DESCRIPTION
Reduce the load that our continuous-integration system puts on luajit.org.