### PR TITLE
Print empty arrays/tables, so PF_VERBOSE does not cause crashes.

### DIFF
--- a/src/pf/utils.lua
+++ b/src/pf/utils.lua
@@ -116,7 +116,11 @@ function pp(expr, indent, suffix)
          pp(expr[#expr], indent, ' }'..suffix)
       end
    elseif type(expr) == 'table' then
-      error('unimplemented')
+      if #expr == 0 then
+         print(indent .. '{}')
+      else
+         error('unimplemented')
+      end
    else
       error("unsupported type "..type(expr))
    end

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -8,6 +8,8 @@ all:
 
 check: quickcheck
 	./test-matches data
+	# Make sure PF_VERBOSE isn't causing crashes
+	PF_VERBOSE=1 ../tools/pflua-compile "ip" >/dev/null 2>&1
 
 $(TEST_SAVEFILE):
 	wget --output-document $@ $(TEST_SAVEFILE_URL)


### PR DESCRIPTION
See https://github.com/Igalia/pflua/issues/148
A lightweight regression test has been added to the Makefile.