### PR TITLE
Refactor Makefile path handling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
-LUAJIT_O := deps/luajit/src/libluajit.a
+include common.mk
+LUAJIT_O := $(ABS_TOP_SRCDIR)/deps/luajit/src/libluajit.a
 
 LUAJIT_CFLAGS := -DLUAJIT_USE_PERFTOOLS -DLUAJIT_USE_GDBJIT
 

--- a/common.mk
+++ b/common.mk
@@ -1,0 +1,2 @@
+ABS_TOP_SRCDIR:=$(shell cd $(TOP_SRCDIR) && pwd)
+LUAJIT=$(ABS_TOP_SRCDIR)/deps/luajit/usr/local/bin/luajit

--- a/common.mk
+++ b/common.mk
@@ -1,2 +1,3 @@
 ABS_TOP_SRCDIR:=$(shell cd $(TOP_SRCDIR) && pwd)
 LUAJIT=$(ABS_TOP_SRCDIR)/deps/luajit/usr/local/bin/luajit
+PATH := $(ABS_TOP_SRCDIR)/deps/luajit/usr/local/bin:$(PATH)

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -1,4 +1,5 @@
-PATH := ../deps/luajit/usr/local/bin:$(PATH)
+TOP_SRCDIR:=..
+include $(TOP_SRCDIR)/common.mk
 
 EXAMPLES = \
 	tcp-port-80.md \

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,4 +1,7 @@
-PATH := .:../deps/luajit/usr/local/bin:$(PATH)
+TOP_SRCDIR:=..
+include $(TOP_SRCDIR)/common.mk
+
+PATH := .:$(ABS_TOP_SRCDIR)/deps/luajit/usr/local/bin:$(PATH)
 
 all:
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,8 +1,6 @@
 TOP_SRCDIR:=..
 include $(TOP_SRCDIR)/common.mk
 
-PATH := .:$(ABS_TOP_SRCDIR)/deps/luajit/usr/local/bin:$(PATH)
-
 all:
 
 clean:

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,7 +1,9 @@
-PATH := ../deps/luajit/usr/local/bin:$(PATH)
+TOP_SRCDIR:=..
+include $(TOP_SRCDIR)/common.mk
+
 TEST_SAVEFILE_URL='https://github.com/Igalia/pflua-test/blob/master/savefiles/wingolog.org.pcap?raw=true'
 TEST_SAVEFILE=data/wingolog.pcap
-PFLUA_QUICKCHECK=../tools/pflua-quickcheck
+PFLUA_QUICKCHECK=$(ABS_TOP_SRCDIR)/tools/pflua-quickcheck
 
 all:
 	@true
@@ -9,7 +11,7 @@ all:
 check: quickcheck
 	./test-matches data
 	# Make sure PF_VERBOSE isn't causing crashes
-	PF_VERBOSE=1 ../tools/pflua-compile "ip" >/dev/null 2>&1
+	PF_VERBOSE=1 $(ABS_TOP_SRCDIR)/tools/pflua-compile "ip" >/dev/null 2>&1
 
 $(TEST_SAVEFILE):
 	wget --output-document $@ $(TEST_SAVEFILE_URL)

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -1,4 +1,7 @@
-PATH := ../deps/luajit/usr/local/bin:$(PATH)
+TOP_SRCDIR:=..
+include $(TOP_SRCDIR)/common.mk
+
+PATH := $(ABS_TOP_SRCDIR)/deps/luajit/usr/local/bin:$(PATH)
 
 all:
 

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -1,8 +1,6 @@
 TOP_SRCDIR:=..
 include $(TOP_SRCDIR)/common.mk
 
-PATH := $(ABS_TOP_SRCDIR)/deps/luajit/usr/local/bin:$(PATH)
-
 all:
 
 clean:


### PR DESCRIPTION
Pflua uses recursive make, without autotools.
This change adds a $ABS_TOP_SRCDIR variable, inspired by autoconf,
to make the way the Makefiles deal with paths be less fragile.

Note that this intentionally means that only the top-level Makefile should
be invoked by hand; the rest now depend on it. For now, this can be worked
around by setting ABS_TOP_SRCDIR appropriately while invoking the dependent
Makefiles, but this is not advised.