### PR TITLE
Added pflang-level regression tests for bug 132

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -2,7 +2,7 @@ TOP_SRCDIR:=..
 include $(TOP_SRCDIR)/common.mk
 
 # Tests where the pure-lua pipeline and/or bpf-lua pipeline diverged from libpcap.
-PFLANG_REGRESSION_PL_TESTS := $(wildcard pflang-reg/pl*)
+PFLANG_REGRESSION_TESTS := $(wildcard pflang-reg/*)
 
 TEST_SAVEFILE_URL='https://github.com/Igalia/pflua-test/blob/master/savefiles/wingolog.org.pcap?raw=true'
 TEST_SAVEFILE=data/wingolog.pcap
@@ -11,7 +11,7 @@ PFLUA_QUICKCHECK=$(ABS_TOP_SRCDIR)/tools/pflua-quickcheck
 all:
 	@true
 
-check: pflang_regression_tests quickcheck
+check: regression quickcheck
 	./test-matches data
 	# Make sure PF_VERBOSE isn't causing crashes
 	PF_VERBOSE=1 $(ABS_TOP_SRCDIR)/tools/pflua-compile "ip" >/dev/null 2>&1
@@ -25,10 +25,11 @@ quickcheck: $(TEST_SAVEFILE)
 	$(PFLUA_QUICKCHECK) properties/opt_eq_unopt $(TEST_SAVEFILE)
 	$(PFLUA_QUICKCHECK) properties/opt_eq_unopt $(TEST_SAVEFILE) test-filters
 
-pflang_regression_tests: $(TEST_SAVEFILE) $(PFLANG_REGRESSION_PL_TESTS)
+regression: pflang_regression_tests
 
-.PHONY: $(PFLANG_REGRESSION_PL_TESTS)
-$(PFLANG_REGRESSION_PL_TESTS):
-	$(ABS_TOP_SRCDIR)/tools/pipe-lua-libpcap-match $(shell cat $@)
+pflang_regression_tests: $(TEST_SAVEFILE) $(PFLANG_REGRESSION_TESTS)
 
+.PHONY: $(PFLANG_REGRESSION_TESTS)
+$(PFLANG_REGRESSION_TESTS):
+	cd pflang-reg && ./`basename $@`
 .SERIAL: all

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -31,5 +31,5 @@ pflang_regression_tests: $(TEST_SAVEFILE) $(PFLANG_REGRESSION_TESTS)
 
 .PHONY: $(PFLANG_REGRESSION_TESTS)
 $(PFLANG_REGRESSION_TESTS):
-	cd pflang-reg && ./`basename $@`
+	./$@
 .SERIAL: all

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,6 +1,9 @@
 TOP_SRCDIR:=..
 include $(TOP_SRCDIR)/common.mk
 
+# Tests where the pure-lua pipeline and/or bpf-lua pipeline diverged from libpcap.
+PFLANG_REGRESSION_PL_TESTS := $(wildcard pflang-reg/pl*)
+
 TEST_SAVEFILE_URL='https://github.com/Igalia/pflua-test/blob/master/savefiles/wingolog.org.pcap?raw=true'
 TEST_SAVEFILE=data/wingolog.pcap
 PFLUA_QUICKCHECK=$(ABS_TOP_SRCDIR)/tools/pflua-quickcheck
@@ -8,7 +11,7 @@ PFLUA_QUICKCHECK=$(ABS_TOP_SRCDIR)/tools/pflua-quickcheck
 all:
 	@true
 
-check: quickcheck
+check: pflang_regression_tests quickcheck
 	./test-matches data
 	# Make sure PF_VERBOSE isn't causing crashes
 	PF_VERBOSE=1 $(ABS_TOP_SRCDIR)/tools/pflua-compile "ip" >/dev/null 2>&1
@@ -21,5 +24,11 @@ quickcheck: $(TEST_SAVEFILE)
 	$(PFLUA_QUICKCHECK) properties/pflua_math_eq_libpcap_math
 	$(PFLUA_QUICKCHECK) properties/opt_eq_unopt $(TEST_SAVEFILE)
 	$(PFLUA_QUICKCHECK) properties/opt_eq_unopt $(TEST_SAVEFILE) test-filters
+
+pflang_regression_tests: $(TEST_SAVEFILE) $(PFLANG_REGRESSION_PL_TESTS)
+
+.PHONY: $(PFLANG_REGRESSION_PL_TESTS)
+$(PFLANG_REGRESSION_PL_TESTS):
+	$(ABS_TOP_SRCDIR)/tools/pipe-lua-libpcap-match $(shell cat $@)
 
 .SERIAL: all

--- a/tests/pflang-reg/pl-bug132-icmp6_or_ip
+++ b/tests/pflang-reg/pl-bug132-icmp6_or_ip
@@ -1,0 +1,1 @@
+data/wingolog.pcap "icmp6 or ip" 2442

--- a/tests/pflang-reg/pl-bug132-icmp6_or_ip
+++ b/tests/pflang-reg/pl-bug132-icmp6_or_ip
@@ -1,2 +1,3 @@
 #!/bin/bash
-../../env pipe-lua-libpcap-match ../data/wingolog.pcap "icmp6 or ip" 2442
+thisdir=$(dirname $0)
+"${thisdir}/../../env" pipe-lua-libpcap-match "${thisdir}/../data/wingolog.pcap" "icmp6 or ip" 2442

--- a/tests/pflang-reg/pl-bug132-icmp6_or_ip
+++ b/tests/pflang-reg/pl-bug132-icmp6_or_ip
@@ -1,1 +1,2 @@
-data/wingolog.pcap "icmp6 or ip" 2442
+#!/bin/bash
+../../env pipe-lua-libpcap-match ../data/wingolog.pcap "icmp6 or ip" 2442

--- a/tests/pflang-reg/pl-bug132-icmp6_or_portrange
+++ b/tests/pflang-reg/pl-bug132-icmp6_or_portrange
@@ -1,0 +1,1 @@
+data/wingolog.pcap "icmp6 or portrange 14682-50101" 14951

--- a/tests/pflang-reg/pl-bug132-icmp6_or_portrange
+++ b/tests/pflang-reg/pl-bug132-icmp6_or_portrange
@@ -1,1 +1,2 @@
-data/wingolog.pcap "icmp6 or portrange 14682-50101" 14951
+#!/bin/bash
+../../env pipe-lua-libpcap-match ../data/wingolog.pcap "icmp6 or portrange 14682-50101" 14951

--- a/tests/pflang-reg/pl-bug132-icmp6_or_portrange
+++ b/tests/pflang-reg/pl-bug132-icmp6_or_portrange
@@ -1,2 +1,3 @@
 #!/bin/bash
-../../env pipe-lua-libpcap-match ../data/wingolog.pcap "icmp6 or portrange 14682-50101" 14951
+thisdir=$(dirname $0)
+"${thisdir}/../../env" pipe-lua-libpcap-match "${thisdir}/../data/wingolog.pcap" "icmp6 or portrange 14682-50101" 14951

--- a/tests/pflang-reg/pl-bug132-not_icmp6
+++ b/tests/pflang-reg/pl-bug132-not_icmp6
@@ -1,2 +1,3 @@
 #!/bin/bash
-../../env pipe-lua-libpcap-match ../data/wingolog.pcap "not icmp6" 1
+thisdir=$(dirname $0)
+"${thisdir}/../../env" pipe-lua-libpcap-match "${thisdir}/../data/wingolog.pcap" "not icmp6" 1

--- a/tests/pflang-reg/pl-bug132-not_icmp6
+++ b/tests/pflang-reg/pl-bug132-not_icmp6
@@ -1,1 +1,2 @@
-data/wingolog.pcap "not icmp6" 1
+#!/bin/bash
+../../env pipe-lua-libpcap-match ../data/wingolog.pcap "not icmp6" 1

--- a/tests/pflang-reg/pl-bug132-not_icmp6
+++ b/tests/pflang-reg/pl-bug132-not_icmp6
@@ -1,0 +1,1 @@
+data/wingolog.pcap "not icmp6" 1


### PR DESCRIPTION
Regression tests for bug 132.
https://github.com/Igalia/pflua/issues/132
pure-lua 'icmp6 or (expr)' and "not icmp6" broken