### PR TITLE
Set TOP_SRCDIR in the root Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
+TOP_SRCDIR:=.
 include common.mk
 LUAJIT_O := $(ABS_TOP_SRCDIR)/deps/luajit/src/libluajit.a
 


### PR DESCRIPTION
It was previously unset, which was a latent bug.