### PR TITLE
Packet access doesn't abort if the packet is of the wrong type

### DIFF
--- a/doc/dst-portrange-80-90.md
+++ b/doc/dst-portrange-80-90.md
@@ -98,37 +98,38 @@ return function(P,length)
       if band(cast("uint16_t*", P+20)[0],65311) ~= 0 then return false end
       local var9 = lshift(band(P[14],15),2)
       if (var9 + 18) > length then return false end
-      local var16 = rshift(bswap(cast("uint16_t*", P+(var9 + 16))[0]), 16)
-      if var16 < 80 then return false end
-      return var16 <= 90
+      if rshift(bswap(cast("uint16_t*", P+(var9 + 16))[0]), 16) < 80 then return false end
+      local var19 = lshift(band(P[14],15),2)
+      if (var19 + 18) > length then return false end
+      return rshift(bswap(cast("uint16_t*", P+(var19 + 16))[0]), 16) <= 90
    else
       if length < 58 then return false end
       if var1 ~= 56710 then return false end
-      local var24 = P[20]
-      if var24 == 6 then goto L24 end
+      local var28 = P[20]
+      if var28 == 6 then goto L26 end
       do
-         if var24 ~= 44 then goto L27 end
+         if var28 ~= 44 then goto L29 end
          do
-            if P[54] == 6 then goto L24 end
-            goto L27
+            if P[54] == 6 then goto L26 end
+            goto L29
          end
-::L27::
-         if var24 == 17 then goto L24 end
-         if var24 ~= 44 then goto L33 end
+::L29::
+         if var28 == 17 then goto L26 end
+         if var28 ~= 44 then goto L35 end
          do
-            if P[54] == 17 then goto L24 end
-            goto L33
+            if P[54] == 17 then goto L26 end
+            goto L35
          end
-::L33::
-         if var24 == 132 then goto L24 end
-         if var24 ~= 44 then return false end
-         if P[54] == 132 then goto L24 end
+::L35::
+         if var28 == 132 then goto L26 end
+         if var28 ~= 44 then return false end
+         if P[54] == 132 then goto L26 end
          return false
       end
-::L24::
-      local var34 = rshift(bswap(cast("uint16_t*", P+56)[0]), 16)
-      if var34 < 80 then return false end
-      return var34 <= 90
+::L26::
+      local var38 = rshift(bswap(cast("uint16_t*", P+56)[0]), 16)
+      if var38 < 80 then return false end
+      return var38 <= 90
    end
 end
 

--- a/doc/portrange-0-6000.md
+++ b/doc/portrange-0-6000.md
@@ -113,38 +113,45 @@ return function(P,length)
          return false
       end
 ::L8::
-      if band(cast("uint16_t*", P+20)[0],65311) ~= 0 then return false end
-      local var9 = lshift(band(P[14],15),2)
-      local var10 = (var9 + 16)
-      if var10 > length then return false end
-      if rshift(bswap(cast("uint16_t*", P+(var9 + 14))[0]), 16) <= 6000 then return true end
-      if (var9 + 18) > length then return false end
-      return rshift(bswap(cast("uint16_t*", P+var10)[0]), 16) <= 6000
+      local var6 = band(cast("uint16_t*", P+20)[0],65311)
+      if var6 ~= 0 then goto L15 end
+      do
+         local var9 = lshift(band(P[14],15),2)
+         if (var9 + 16) > length then return false end
+         if rshift(bswap(cast("uint16_t*", P+(var9 + 14))[0]), 16) <= 6000 then return true end
+         goto L15
+      end
+::L15::
+      if var6 ~= 0 then return false end
+      if (lshift(band(P[14],15),2) + 18) > length then return false end
+      local var25 = lshift(band(P[14],15),2)
+      if (var25 + 18) > length then return false end
+      return rshift(bswap(cast("uint16_t*", P+(var25 + 16))[0]), 16) <= 6000
    else
       if length < 56 then return false end
       if var1 ~= 56710 then return false end
-      local var28 = P[20]
-      if var28 == 6 then goto L26 end
+      local var34 = P[20]
+      if var34 == 6 then goto L32 end
       do
-         if var28 ~= 44 then goto L29 end
+         if var34 ~= 44 then goto L35 end
          do
-            if P[54] == 6 then goto L26 end
-            goto L29
-         end
-::L29::
-         if var28 == 17 then goto L26 end
-         if var28 ~= 44 then goto L35 end
-         do
-            if P[54] == 17 then goto L26 end
+            if P[54] == 6 then goto L32 end
             goto L35
          end
 ::L35::
-         if var28 == 132 then goto L26 end
-         if var28 ~= 44 then return false end
-         if P[54] == 132 then goto L26 end
+         if var34 == 17 then goto L32 end
+         if var34 ~= 44 then goto L41 end
+         do
+            if P[54] == 17 then goto L32 end
+            goto L41
+         end
+::L41::
+         if var34 == 132 then goto L32 end
+         if var34 ~= 44 then return false end
+         if P[54] == 132 then goto L32 end
          return false
       end
-::L26::
+::L32::
       if rshift(bswap(cast("uint16_t*", P+54)[0]), 16) <= 6000 then return true end
       if length < 58 then return false end
       return rshift(bswap(cast("uint16_t*", P+56)[0]), 16) <= 6000

--- a/doc/proto-47.md
+++ b/doc/proto-47.md
@@ -55,8 +55,20 @@ end
 local cast = require("ffi").cast
 return function(P,length)
    if length < 34 then return false end
-   if cast("uint16_t*", P+12)[0] ~= 8 then return false end
-   return P[23] == 47
+   local var1 = cast("uint16_t*", P+12)[0]
+   if var1 ~= 8 then goto L7 end
+   do
+      if P[23] == 47 then return true end
+      goto L7
+   end
+::L7::
+   if length < 54 then return false end
+   if var1 ~= 56710 then return false end
+   local var4 = P[20]
+   if var4 == 47 then return true end
+   if length < 55 then return false end
+   if var4 ~= 44 then return false end
+   return P[54] == 47
 end
 
 ```

--- a/src/pf/expand.lua
+++ b/src/pf/expand.lua
@@ -647,7 +647,7 @@ local function expand_atalk(expr)
   return { 'or',
            has_ether_protocol(PROTO_ATALK),
            { 'if', { '>', { '[ether]', ETHER_TYPE, 2}, ETHER_MAX_LEN },
-             { 'fail' },
+             { 'false' },
              { 'and',
                { '=', { '[ether]', ETHER_PAYLOAD + 4, 2 }, ATALK_ID_1 },
                { '=', { '[ether]', ETHER_PAYLOAD, 4 }, ATALK_ID_2 } } } }
@@ -657,7 +657,7 @@ local function expand_aarp(expr)
   return { 'or',
            has_ether_protocol(PROTO_AARP),
            { 'if', { '>', { '[ether]', ETHER_TYPE, 2}, ETHER_MAX_LEN },
-             { 'fail' },
+             { 'false' },
              { 'and',
                { '=', { '[ether]', ETHER_PAYLOAD + 4, 2 }, PROTO_AARP },
                { '=', { '[ether]', ETHER_PAYLOAD, 4 }, AARP_ID } } } }
@@ -695,7 +695,7 @@ local function expand_ipx(expr)
   return { 'or',
            has_ether_protocol(PROTO_IPX),
            { 'if', { '>', { '[ether]', ETHER_TYPE, 2}, ETHER_MAX_LEN },
-             { 'fail' },
+             { 'false' },
              { 'or',
                { 'and',
                  { '=', { '[ether]', ETHER_PAYLOAD + 4, 2 }, PROTO_IPX },
@@ -783,7 +783,7 @@ local function expand_decnet_src(expr)
                 { '=', { '[ether]', ETHER_PAYLOAD + 17, 2}, addr_int },
                 { 'if', { '=', { '&', { '[ether]', ETHER_PAYLOAD + 2, 2}, 65287 }, 33030 },
                   { '=', { '[ether]', ETHER_PAYLOAD + 18, 2}, addr_int },
-                  { 'fail' } } } } }
+                  { 'false' } } } } }
 end
 local function expand_decnet_dst(expr)
    local addr = expr[2]
@@ -796,7 +796,7 @@ local function expand_decnet_dst(expr)
                 { '=', { '[ether]', ETHER_PAYLOAD + 9, 2}, addr_int },
                 { 'if', { '=', { '&', { '[ether]', ETHER_PAYLOAD + 2, 2}, 65287 }, 33030 },
                   { '=', { '[ether]', ETHER_PAYLOAD + 10, 2}, addr_int },
-                  { 'fail' } } } } }
+                  { 'false' } } } } }
 end
 local function expand_decnet_host(expr)
    return { 'or', expand_decnet_src(expr), expand_decnet_dst(expr) }
@@ -822,7 +822,7 @@ local function expand_isis_protocol(...)
    end
    return { 'if', has_iso_protocol(PROTO_ISIS),
             concat('or', { '[ether]', ETHER_PAYLOAD + 7, 1 }, {...} ),
-            { 'fail' } }
+            { 'false' } }
 end
 local function expand_l1(expr)
    return expand_isis_protocol(L1_IIH, L1_LSP, L1_CSNP, L1_PSNP, PTP_IIH)
@@ -1032,7 +1032,7 @@ local function expand_offset(level, dlt)
    assert(dlt == "EN10MB", "Encapsulation other than EN10MB unimplemented")
    local function guard_expr(expr)
       local test, guards = expand_relop(expr, dlt)
-      return concat(guards, { { test, { 'fail' } } })
+      return concat(guards, { { test, { 'false' } } })
    end
    local function guard_ether_protocol(proto)
       return concat(guard_expr(has_ether_protocol(proto)),


### PR DESCRIPTION
* src/pf/expand.lua (expand_atalk, expand_aarp, expand_ipx)
  (expand_decnet_src, expand_decnet_dst, expand_isis_protocol): Use
  'false' as the failure continuation, not 'fail'.
  (expand_offset): Use 'false' as the failure continuation when checking
  that a packet is of a certain protocol.  Fixes #171.

We seem to uncover some CSE failures though :(