### PR TITLE
Represent tail continuations in optimize IR

### DIFF
--- a/doc/dst-host-192.68.1.1-and-greater-100.md
+++ b/doc/dst-host-192.68.1.1-and-greater-100.md
@@ -60,13 +60,13 @@ return function(P,length)
       if cast("uint32_t*", P+30)[0] == 16860352 then goto L6 end
       goto L7
    else
-      if length < 42 then return false end
-      if var1 == 1544 then goto L12 end
+      if var1 == 1544 then goto L10 end
       do
-         if var1 == 13696 then goto L12 end
+         if var1 == 13696 then goto L10 end
          return false
       end
-::L12::
+::L10::
+      if length < 42 then return false end
       if cast("uint32_t*", P+38)[0] == 16860352 then goto L6 end
       goto L7
    end

--- a/doc/dst-portrange-80-90.md
+++ b/doc/dst-portrange-80-90.md
@@ -98,38 +98,37 @@ return function(P,length)
       if band(cast("uint16_t*", P+20)[0],65311) ~= 0 then return false end
       local var9 = lshift(band(P[14],15),2)
       if (var9 + 18) > length then return false end
-      if rshift(bswap(cast("uint16_t*", P+(var9 + 16))[0]), 16) < 80 then return false end
-      local var19 = lshift(band(P[14],15),2)
-      if (var19 + 18) > length then return false end
-      return rshift(bswap(cast("uint16_t*", P+(var19 + 16))[0]), 16) <= 90
+      local var16 = rshift(bswap(cast("uint16_t*", P+(var9 + 16))[0]), 16)
+      if var16 < 80 then return false end
+      return var16 <= 90
    else
       if length < 58 then return false end
       if var1 ~= 56710 then return false end
-      local var28 = P[20]
-      if var28 == 6 then goto L26 end
+      local var24 = P[20]
+      if var24 == 6 then goto L24 end
       do
-         if var28 ~= 44 then goto L29 end
+         if var24 ~= 44 then goto L27 end
          do
-            if P[54] == 6 then goto L26 end
-            goto L29
+            if P[54] == 6 then goto L24 end
+            goto L27
          end
-::L29::
-         if var28 == 17 then goto L26 end
-         if var28 ~= 44 then goto L35 end
+::L27::
+         if var24 == 17 then goto L24 end
+         if var24 ~= 44 then goto L33 end
          do
-            if P[54] == 17 then goto L26 end
-            goto L35
+            if P[54] == 17 then goto L24 end
+            goto L33
          end
-::L35::
-         if var28 == 132 then goto L26 end
-         if var28 ~= 44 then return false end
-         if P[54] == 132 then goto L26 end
+::L33::
+         if var24 == 132 then goto L24 end
+         if var24 ~= 44 then return false end
+         if P[54] == 132 then goto L24 end
          return false
       end
-::L26::
-      local var38 = rshift(bswap(cast("uint16_t*", P+56)[0]), 16)
-      if var38 < 80 then return false end
-      return var38 <= 90
+::L24::
+      local var34 = rshift(bswap(cast("uint16_t*", P+56)[0]), 16)
+      if var34 < 80 then return false end
+      return var34 <= 90
    end
 end
 

--- a/doc/portrange-0-6000.md
+++ b/doc/portrange-0-6000.md
@@ -113,45 +113,38 @@ return function(P,length)
          return false
       end
 ::L8::
-      local var6 = band(cast("uint16_t*", P+20)[0],65311)
-      if var6 ~= 0 then goto L15 end
-      do
-         local var9 = lshift(band(P[14],15),2)
-         if (var9 + 16) > length then return false end
-         if rshift(bswap(cast("uint16_t*", P+(var9 + 14))[0]), 16) <= 6000 then return true end
-         goto L15
-      end
-::L15::
-      if var6 ~= 0 then return false end
-      if (lshift(band(P[14],15),2) + 18) > length then return false end
-      local var25 = lshift(band(P[14],15),2)
-      if (var25 + 18) > length then return false end
-      return rshift(bswap(cast("uint16_t*", P+(var25 + 16))[0]), 16) <= 6000
+      if band(cast("uint16_t*", P+20)[0],65311) ~= 0 then return false end
+      local var9 = lshift(band(P[14],15),2)
+      local var10 = (var9 + 16)
+      if var10 > length then return false end
+      if rshift(bswap(cast("uint16_t*", P+(var9 + 14))[0]), 16) <= 6000 then return true end
+      if (var9 + 18) > length then return false end
+      return rshift(bswap(cast("uint16_t*", P+var10)[0]), 16) <= 6000
    else
       if length < 56 then return false end
       if var1 ~= 56710 then return false end
-      local var34 = P[20]
-      if var34 == 6 then goto L32 end
+      local var28 = P[20]
+      if var28 == 6 then goto L26 end
       do
-         if var34 ~= 44 then goto L35 end
+         if var28 ~= 44 then goto L29 end
          do
-            if P[54] == 6 then goto L32 end
+            if P[54] == 6 then goto L26 end
+            goto L29
+         end
+::L29::
+         if var28 == 17 then goto L26 end
+         if var28 ~= 44 then goto L35 end
+         do
+            if P[54] == 17 then goto L26 end
             goto L35
          end
 ::L35::
-         if var34 == 17 then goto L32 end
-         if var34 ~= 44 then goto L41 end
-         do
-            if P[54] == 17 then goto L32 end
-            goto L41
-         end
-::L41::
-         if var34 == 132 then goto L32 end
-         if var34 ~= 44 then return false end
-         if P[54] == 132 then goto L32 end
+         if var28 == 132 then goto L26 end
+         if var28 ~= 44 then return false end
+         if P[54] == 132 then goto L26 end
          return false
       end
-::L32::
+::L26::
       if rshift(bswap(cast("uint16_t*", P+54)[0]), 16) <= 6000 then return true end
       if length < 58 then return false end
       return rshift(bswap(cast("uint16_t*", P+56)[0]), 16) <= 6000

--- a/doc/src-host-192.68.1.1-and-less-100.md
+++ b/doc/src-host-192.68.1.1-and-less-100.md
@@ -60,13 +60,13 @@ return function(P,length)
       if cast("uint32_t*", P+26)[0] == 16860352 then goto L6 end
       goto L7
    else
-      if length < 42 then return false end
-      if var1 == 1544 then goto L12 end
+      if var1 == 1544 then goto L10 end
       do
-         if var1 == 13696 then goto L12 end
+         if var1 == 13696 then goto L10 end
          return false
       end
-::L12::
+::L10::
+      if length < 42 then return false end
       if cast("uint32_t*", P+28)[0] == 16860352 then goto L6 end
       goto L7
    end

--- a/src/pf/anf.lua
+++ b/src/pf/anf.lua
@@ -11,6 +11,8 @@ local binops = set(
 )
 local unops = set('ntohs', 'ntohl', 'uint32', 'int32')
 
+local simple = set('true', 'false', 'match', 'fail')
+
 local count = 0
 
 local function fresh()
@@ -75,7 +77,7 @@ local function lower_bool(expr, k)
          return k({ 'if', test, lower(t), lower(f) })
       end
       return lower_bool(test, have_test)
-   elseif op == 'true' or op == 'false' or op == 'fail' then
+   elseif simple[op] then
       return k(expr)
    else
       return lower_comparison(expr, k)
@@ -129,7 +131,7 @@ local function cse(expr)
          end
       elseif op == 'if' then
          return { 'if', visit(expr[2], env), visit(expr[3], env), visit(expr[4], env) }
-      elseif op == 'true' or op == 'false' or op == 'fail' then
+      elseif simple[op] then
          return expr
       else
          assert(relops[op])
@@ -164,7 +166,7 @@ local function inline_single_use_variables(expr)
          elseif binops[op] then
             count(expr[2])
             count(expr[3])
-         elseif op == 'true' or op == 'false' or op == 'fail' then
+         elseif simple[op] then
 
          else 
             assert(op == '[]')
@@ -203,7 +205,7 @@ local function inline_single_use_variables(expr)
          end
       elseif op == 'if' then
          return { 'if', subst(expr[2]), subst(expr[3]), subst(expr[4]) }
-      elseif op == 'true' or op == 'false' or op == 'fail' then
+      elseif simple[op] then
          return expr
       else
          assert(relops[op])

--- a/src/pf/ssa.lua
+++ b/src/pf/ssa.lua
@@ -75,6 +75,8 @@ local function lower(expr)
          finish_goto(block, kt)
       elseif op == 'false' then
          finish_goto(block, kf)
+      elseif op == 'match' then
+         finish_return(block, { 'true' })
       elseif op == 'fail' then
          finish_return(block, { 'false' })
       else


### PR DESCRIPTION
* src/pf/optimize.lua (simple): Add an operator 'match', for 'true' in
  tail position.
  (simplify): Always lower 'false' in tail position to 'fail', and lower
  'true' to 'match'.  That way we won't need to eta() to identify
  accept/reject continuations of an "if"'s test -- we just look at the
  consequent expressions.
  (infer_ranges, lhoist): Lose the eta conversion.
  (optimize_inner): Pass the initial "is-tail=true" flag to simplify.
  (selftest): Adjust expectations.

* src/pf/anf.lua:
* src/pf/ssa.lua: Handle 'match'.

* doc/dst-host-192.68.1.1-and-greater-100.md:
* doc/src-host-192.68.1.1-and-less-100.md: Regenerate.