### PR TITLE
Regression test for bug 83, floatmul

### DIFF
--- a/tests/pflang-reg/pl-bug00083-floatmul
+++ b/tests/pflang-reg/pl-bug00083-floatmul
@@ -1,0 +1,3 @@
+#!/bin/bash
+thisdir=$(dirname $0)
+"${thisdir}/../../env" pflua-pipelines-match "${thisdir}/../data/arp.pcap" "405434949 * 1881196573 == 1588910545" 1


### PR DESCRIPTION
https://github.com/Igalia/pflua/issues/83
Pflua: multiplications used to use floats, leading to different results
with large operands when compared to the correct integer multiplications.

Do not merge this yet; the regression test depends on a fix to bug https://github.com/Igalia/pflua/issues/185