### PR TITLE
Added a regression test for bug 171

### DIFF
--- a/tests/pflang-reg/pl-bug-171-arpind_or_tcp
+++ b/tests/pflang-reg/pl-bug-171-arpind_or_tcp
@@ -1,0 +1,3 @@
+#!/bin/bash
+thisdir=$(dirname $0)
+"${thisdir}/../../env" pflua-pipelines-match "${thisdir}/../data/wingolog.pcap" "arp[1] > 1 or tcp" 3584


### PR DESCRIPTION
https://github.com/Igalia/pflua/issues/171
(Packet indexing should cause conditions and assertions)

This also serves as a regression test for bug 166.
https://github.com/Igalia/pflua/issues/166
(More 'or' cases broken with packet indexing)