### PR TITLE
Added a regression test for bug 130, libpcap failfast

### DIFF
--- a/tests/pflang-reg/pl-bug130-allreject
+++ b/tests/pflang-reg/pl-bug130-allreject
@@ -1,0 +1,3 @@
+#!/bin/bash
+thisdir=$(dirname $0)
+"${thisdir}/../../env" pflua-pipelines-match "${thisdir}/../data/arp.pcap" "portrange 1-2 and arp" 1


### PR DESCRIPTION
https://github.com/Igalia/pflua/issues/130

Note that this is a workaround that makes pflua's libpcap pipeline
behave like the other pipelines, rather than failing fast like
libpcap does.