### PR TITLE
Simplify 'if A fail fail' to 'fail'

### DIFF
--- a/src/pf/optimize.lua
+++ b/src/pf/optimize.lua
@@ -239,6 +239,7 @@ function simplify_if(test, t, f)
    elseif t[1] == 'true' and f[1] == 'false' then return test
    -- 'match' will only be residualized in tail position.
    elseif t[1] == 'match' and f[1] == 'fail' then return test
+   elseif t[1] == 'fail' and f[1] == 'fail' then return { 'fail' }
    -- FIXME: Memoize cfkey to avoid O(n^2) badness.
    elseif op == 'if' then
       if test[3][1] == 'fail' then


### PR DESCRIPTION
`if A fail fail` can appear when some checks are conflicting, e.g. `tcp and tcp[100] == 1` used to compile to

```lua
local lshift = require("bit").lshift
local band = require("bit").band
local cast = require("ffi").cast
return function(P,length)
   if length < 14 then return false end
   local var1 = cast("uint16_t*", P+12)[0]
   if var1 == 8 then
      if length < 54 then return false end
      if P[23] ~= 6 then return false end
      if band(cast("uint16_t*", P+20)[0],65311) ~= 0 then return false end
      local var7 = lshift(band(P[14],15),2)
      if (var7 + 115) > length then return false end
      return P[(var7 + 114)] == 1
   else
      if var1 ~= 56710 then return false end
      if length < 54 then return false end
      local var15 = P[20]
      return false
   end
end
```

Note the path that always returns false. With this change it compiles to

```lua
local lshift = require("bit").lshift
local band = require("bit").band
local cast = require("ffi").cast
return function(P,length)
   if length < 54 then return false end
   if cast("uint16_t*", P+12)[0] ~= 8 then return false end
   if P[23] ~= 6 then return false end
   if band(cast("uint16_t*", P+20)[0],65311) ~= 0 then return false end
   local var7 = lshift(band(P[14],15),2)
   if (var7 + 115) > length then return false end
   return P[(var7 + 114)] == 1
end
```
Which is same as code for `tcp[100] == 1`.

Some optimizations are also possible for other cases when true and false branches of an `if` are identical, but I couldn't find an example of that.