### PR TITLE
Cleanup of function passed to 'memoize'

### DIFF
--- a/src/pf/optimize.lua
+++ b/src/pf/optimize.lua
@@ -88,13 +88,12 @@ end
 
 cfkey = memoize(function (expr)
    if type(expr) == 'table' then
-      local parts = {'(', cfkey(expr[1])}
-      for i=2,#expr do
-         parts[i*2-1] = ' '
-         parts[i*2] = cfkey(expr[i])
+      local parts = {'('}
+      for i=1,#expr do
+         parts[i+1] = cfkey(expr[i])
       end
-      parts[#expr*2+1] = ')'
-      return table.concat(parts)
+      parts[#parts+1] = ')'
+      return table.concat(parts, " ")
    else
       return expr
    end


### PR DESCRIPTION
Originally this patch was an attempt to fix #225, but it happened to be unrelated (see #225 for details). The patch is kept as a cleanup.