### PR TITLE
Add address-of pflang extension

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -43,7 +43,8 @@ EXAMPLES = \
 	packet-access-igrp.md \
 	packet-access-vrrp.md \
 	packet-access-sctp.md \
-	icmp6-or-ip.md
+	icmp6-or-ip.md \
+	tcp-address.md
 
 PFLUA = \
 	../src/pf.lua \
@@ -186,3 +187,6 @@ packet-access-sctp.md: $(PFLUA)
 
 icmp6-or-ip.md: $(PFLUA)
 	../tools/dump-markdown "icmp6 or ip" > $@.tmp && mv $@.tmp $@
+
+tcp-address.md: $(PFLUA)
+	../tools/dump-markdown "ether[&tcp[0]] = tcp[0]" > $@.tmp && mv $@.tmp $@

--- a/doc/extensions.md
+++ b/doc/extensions.md
@@ -1,0 +1,46 @@
+# Pflang extensions
+
+Pflua implements "pflang", the language that libpcap uses to express
+packet filters.  Pflua also optionally provides some experimental
+extensions to pflang.  These extensions are experimental, and naturally
+are not supported by the libpcap pipeline.  Please let us know if you
+find them to be useful to you.
+
+## The address-of operator: `&`
+
+By default, this operator is enabled.  To disable, include this code
+somewhere in your app before parsing:
+
+```lua
+require('pf.parse').allow_address_of = false
+```
+
+An AddressExpression is a new kind of arithmetic expression.  The
+grammar is as follows:
+
+```
+AddressExpression := '&' Addressable
+Addressable := PayloadAccessor '[' ArithmeticExpression [ ':' (1|2|4) ] ']'
+PayloadAccessor := 'ip' | 'ip6' | 'tcp' | 'udp' | 'icmp' |
+   'arp' | 'rarp' | 'wlan' | 'ether' | 'fddi' | 'tr' | 'ppp' |
+   'slip' | 'link' | 'radio' | 'ip' | 'ip6' | 'tcp' | 'udp' |
+   'igmp' | 'pim' | 'igrp' | 'vrrp' | 'sctp'
+```
+
+The semantics are that `&foo` returns the address of `foo`, as a byte
+offset from the beginning of the packet.  Therefore if a packet is TCP
+and the first byte of the packet is the first byte of the ethernet
+header, then `ether[&tcp[0]] = tcp[0]` will always be true.
+
+If the packet is not of the correct kind, then the comparison in which
+the AddressExpression is embedded fails to match.  This would be the
+case, for example, if you asked for `&udp[0]` but the packet isn't UDP.
+
+Likewise, if the address isn't within the packet, the containing
+comparison will fail to match.  An example would be `&udp[64]` on a UDP
+packet whose size, including the UDP header but excluding the IP or
+other L2 header is less than 64 bytes.  Note that this behavior differs
+from `udp[64]` on a short packet; such an access causes the whole filter
+to abort (see the
+[pflang](https://github.com/Igalia/pflua/blob/master/doc/pflang.md)
+documentation).

--- a/doc/pflang.md
+++ b/doc/pflang.md
@@ -9,7 +9,9 @@ pleasantly terse and expressive, and has a huge amount of
 domain-specific knowledge baked into it.
 
 At the same time, to a language professional, pflang can be infuriating.
-This page documents some less-known aspects of pflang.
+This page documents some less-known aspects of pflang.  See also [pflua
+extensions to
+pflang](https://github.com/Igalia/pflua/blob/master/doc/extensions.md).
 
 ## Specification
 
@@ -96,8 +98,8 @@ Some parts of pflang are quite surprising.
 One set of restrictions is for packet accessors, e.g. the `ip[0]` in
 `ip[0] == 42`.
 
-* If the packet is not an IPv4 or IPv6 packet, the filter will
-  immediately fail.
+* If the packet is not an IPv4 or IPv6 packet, the clause fails to
+  match.
 
 * If the index (e.g. 0 in this case) is not within the packet, then the
   filter immediately fails.

--- a/doc/tcp-address.md
+++ b/doc/tcp-address.md
@@ -1,0 +1,35 @@
+# ether[&tcp[0]] = tcp[0]
+
+
+## BPF
+
+```
+Filter failed to compile: ../src/pf/libpcap.lua:66: pcap_compile failed```
+
+
+## BPF cross-compiled to Lua
+
+```
+Filter failed to compile: ../src/pf/libpcap.lua:66: pcap_compile failed
+```
+
+
+## Direct pflang compilation
+
+```
+local lshift = require("bit").lshift
+local band = require("bit").band
+local cast = require("ffi").cast
+return function(P,length)
+   if length < 54 then return false end
+   if cast("uint16_t*", P+12)[0] ~= 8 then return false end
+   if P[23] ~= 6 then return false end
+   if band(cast("uint16_t*", P+20)[0],65311) ~= 0 then return false end
+   local var7 = lshift(band(P[14],15),2)
+   if (var7 + 15) > length then return false end
+   local var13 = P[(var7 + 14)]
+   return var13 == var13
+end
+
+```
+

--- a/src/pf/parse.lua
+++ b/src/pf/parse.lua
@@ -1,5 +1,7 @@
 module(...,package.seeall)
 
+allow_address_of = true
+
 local utils = require('pf.utils')
 local constants = require('pf.constants')
 
@@ -740,6 +742,25 @@ local rarp_types = {
 
 local parse_arithmetic
 
+local function parse_addressable(lexer, tok)
+   if not tok then
+      tok = lexer.next({maybe_arithmetic=true})
+      if not addressables[tok] then
+         lexer.error('bad token while parsing addressable: %s', tok)
+      end
+   end
+   lexer.consume('[')
+   local pos = parse_arithmetic(lexer)
+   local size = 1
+   if lexer.check(':') then
+      if lexer.check(1) then size = 1
+      elseif lexer.check(2) then size = 2
+      else lexer.consume(4); size = 4 end
+   end
+   lexer.consume(']')
+   return { '['..tok..']', pos, size}
+end
+
 local function parse_primary_arithmetic(lexer, tok)
    tok = tok or lexer.next({maybe_arithmetic=true})
    if tok == '(' then
@@ -748,17 +769,10 @@ local function parse_primary_arithmetic(lexer, tok)
       return expr
    elseif tok == 'len' or type(tok) == 'number' then
       return tok
+   elseif allow_address_of and tok == '&' then
+      return { 'addr', parse_addressable(lexer) }
    elseif addressables[tok] then
-      lexer.consume('[')
-      local pos = parse_arithmetic(lexer)
-      local size = 1
-      if lexer.check(':') then
-         if lexer.check(1) then size = 1
-         elseif lexer.check(2) then size = 2
-         else lexer.consume(4); size = 4 end
-      end
-      lexer.consume(']')
-      return { '['..tok..']', pos, size}
+      return parse_addressable(lexer, tok)
    else
       -- 'tok' may be a constant
       local val = constants.protocol_header_field_offsets[tok] or

--- a/tools/dump-markdown
+++ b/tools/dump-markdown
@@ -9,10 +9,16 @@ assert(filter, "usage: dump-markdown FILTER")
 
 function out(...) print(string.format(...)) end
 
+function compile(opts)
+   local ok, result = pcall(pf.compile_filter, filter, opts)
+   if not ok then result = 'Filter failed to compile: '..result end
+   return result
+end
+
 out("# %s\n\n", filter)
 out("## BPF\n\n```\n%s```\n\n",
-    pf.compile_filter(filter, {libpcap=true, source=true}))
+    compile({libpcap=true, source=true}))
 out("## BPF cross-compiled to Lua\n\n```\n%s\n```\n\n",
-    pf.compile_filter(filter, {bpf=true, source=true}))
+    compile({bpf=true, source=true}))
 out("## Direct pflang compilation\n\n```\n%s\n```\n",
-    pf.compile_filter(filter, {source=true}))
+    compile({source=true}))


### PR DESCRIPTION
* doc/Makefile (tcp-address.md):
* doc/tcp-address.md: New file.

* doc/pflang.md: Link to extensions.md.  Fix description of what happens
  on ip[0] for a non-IP packet.

* src/pf/parse.lua (allow_address_of): New exported flag, on by
  default.
  (parse_addressable, parse_primary_arithmetic): Add addressable
  parsing.

* tools/dump-markdown: Allow libpcap compilation to fail.