### PR TITLE
Renumber ANF-generated vars for readability

### DIFF
--- a/doc/decnet-host-10.15.md
+++ b/doc/decnet-host-10.15.md
@@ -138,24 +138,24 @@ local band = require("bit").band
 local cast = require("ffi").cast
 return function(P,length)
    if length < 21 then return false end
-   local var2 = band(P[16],7)
-   if var2 == 2 then
+   local v1 = band(P[16],7)
+   if v1 == 2 then
       if cast("uint16_t*", P+19)[0] == 3850 then return true end
       return cast("uint16_t*", P+17)[0] == 3850
    else
       if length < 22 then return false end
-      local var6 = band(cast("uint16_t*", P+16)[0],2047)
-      if var6 == 641 then
+      local v2 = band(cast("uint16_t*", P+16)[0],2047)
+      if v2 == 641 then
          if cast("uint16_t*", P+20)[0] == 3850 then return true end
          return cast("uint16_t*", P+18)[0] == 3850
       else
          if length < 33 then return false end
-         if var2 == 6 then
+         if v1 == 6 then
             if cast("uint16_t*", P+31)[0] == 3850 then return true end
             return cast("uint16_t*", P+23)[0] == 3850
          else
             if length < 34 then return false end
-            if var6 ~= 1665 then return false end
+            if v2 ~= 1665 then return false end
             if cast("uint16_t*", P+32)[0] == 3850 then return true end
             return cast("uint16_t*", P+24)[0] == 3850
          end

--- a/doc/decnet-src-10.15.md
+++ b/doc/decnet-src-10.15.md
@@ -86,21 +86,21 @@ local band = require("bit").band
 local cast = require("ffi").cast
 return function(P,length)
    if length < 21 then return false end
-   local var2 = band(P[16],7)
-   if var2 == 2 then
+   local v1 = band(P[16],7)
+   if v1 == 2 then
       return cast("uint16_t*", P+19)[0] == 3850
    end
    if length < 22 then return false end
-   local var5 = band(cast("uint16_t*", P+16)[0],2047)
-   if var5 == 641 then
+   local v2 = band(cast("uint16_t*", P+16)[0],2047)
+   if v2 == 641 then
       return cast("uint16_t*", P+20)[0] == 3850
    end
    if length < 33 then return false end
-   if var2 == 6 then
+   if v1 == 6 then
       return cast("uint16_t*", P+31)[0] == 3850
    end
    if length < 34 then return false end
-   if var5 ~= 1665 then return false end
+   if v2 ~= 1665 then return false end
    return cast("uint16_t*", P+32)[0] == 3850
 end
 

--- a/doc/dst-host-192.68.1.1-and-greater-100.md
+++ b/doc/dst-host-192.68.1.1-and-greater-100.md
@@ -55,13 +55,13 @@ end
 local cast = require("ffi").cast
 return function(P,length)
    if length < 100 then return false end
-   local var1 = cast("uint16_t*", P+12)[0]
-   if var1 == 8 then
+   local v1 = cast("uint16_t*", P+12)[0]
+   if v1 == 8 then
       return cast("uint32_t*", P+30)[0] == 16860352
    end
-   if var1 == 1544 then goto L8 end
+   if v1 == 1544 then goto L8 end
    do
-      if var1 == 13696 then goto L8 end
+      if v1 == 13696 then goto L8 end
       return false
    end
 ::L8::

--- a/doc/dst-portrange-80-90.md
+++ b/doc/dst-portrange-80-90.md
@@ -85,50 +85,50 @@ local lshift = require("bit").lshift
 local band = require("bit").band
 return function(P,length)
    if length < 34 then return false end
-   local var1 = cast("uint16_t*", P+12)[0]
-   if var1 == 8 then
-      local var2 = P[23]
-      if var2 == 6 then goto L8 end
+   local v1 = cast("uint16_t*", P+12)[0]
+   if v1 == 8 then
+      local v2 = P[23]
+      if v2 == 6 then goto L8 end
       do
-         if var2 == 17 then goto L8 end
-         if var2 == 132 then goto L8 end
+         if v2 == 17 then goto L8 end
+         if v2 == 132 then goto L8 end
          return false
       end
 ::L8::
       if band(cast("uint16_t*", P+20)[0],65311) ~= 0 then return false end
-      local var9 = lshift(band(P[14],15),2)
-      if (var9 + 18) > length then return false end
-      local var16 = rshift(bswap(cast("uint16_t*", P+(var9 + 16))[0]), 16)
-      if var16 < 80 then return false end
-      return var16 <= 90
+      local v3 = lshift(band(P[14],15),2)
+      if (v3 + 18) > length then return false end
+      local v4 = rshift(bswap(cast("uint16_t*", P+(v3 + 16))[0]), 16)
+      if v4 < 80 then return false end
+      return v4 <= 90
    else
       if length < 58 then return false end
-      if var1 ~= 56710 then return false end
-      local var24 = P[20]
-      if var24 == 6 then goto L24 end
+      if v1 ~= 56710 then return false end
+      local v5 = P[20]
+      if v5 == 6 then goto L24 end
       do
-         if var24 ~= 44 then goto L27 end
+         if v5 ~= 44 then goto L27 end
          do
             if P[54] == 6 then goto L24 end
             goto L27
          end
 ::L27::
-         if var24 == 17 then goto L24 end
-         if var24 ~= 44 then goto L33 end
+         if v5 == 17 then goto L24 end
+         if v5 ~= 44 then goto L33 end
          do
             if P[54] == 17 then goto L24 end
             goto L33
          end
 ::L33::
-         if var24 == 132 then goto L24 end
-         if var24 ~= 44 then return false end
+         if v5 == 132 then goto L24 end
+         if v5 ~= 44 then return false end
          if P[54] == 132 then goto L24 end
          return false
       end
 ::L24::
-      local var34 = rshift(bswap(cast("uint16_t*", P+56)[0]), 16)
-      if var34 < 80 then return false end
-      return var34 <= 90
+      local v6 = rshift(bswap(cast("uint16_t*", P+56)[0]), 16)
+      if v6 < 80 then return false end
+      return v6 <= 90
    end
 end
 

--- a/doc/fail-fail.md
+++ b/doc/fail-fail.md
@@ -61,9 +61,9 @@ return function(P,length)
    if cast("uint16_t*", P+12)[0] ~= 8 then return false end
    if P[23] ~= 6 then return false end
    if band(cast("uint16_t*", P+20)[0],65311) ~= 0 then return false end
-   local var7 = lshift(band(P[14],15),2)
-   if (var7 + 115) > length then return false end
-   return P[(var7 + 114)] == 1
+   local v1 = lshift(band(P[14],15),2)
+   if (v1 + 115) > length then return false end
+   return P[(v1 + 114)] == 1
 end
 
 ```

--- a/doc/host-127.0.0.1.md
+++ b/doc/host-127.0.0.1.md
@@ -61,15 +61,15 @@ end
 local cast = require("ffi").cast
 return function(P,length)
    if length < 34 then return false end
-   local var1 = cast("uint16_t*", P+12)[0]
-   if var1 == 8 then
+   local v1 = cast("uint16_t*", P+12)[0]
+   if v1 == 8 then
       if cast("uint32_t*", P+26)[0] == 16777343 then return true end
       return cast("uint32_t*", P+30)[0] == 16777343
    else
       if length < 42 then return false end
-      if var1 == 1544 then goto L12 end
+      if v1 == 1544 then goto L12 end
       do
-         if var1 == 13696 then goto L12 end
+         if v1 == 13696 then goto L12 end
          return false
       end
 ::L12::

--- a/doc/icmp-or-tcp-or-udp.md
+++ b/doc/icmp-or-tcp-or-udp.md
@@ -60,35 +60,35 @@ end
 local cast = require("ffi").cast
 return function(P,length)
    if length < 34 then return false end
-   local var1 = cast("uint16_t*", P+12)[0]
-   if var1 == 8 then
-      local var2 = P[23]
-      if var2 == 1 then return true end
-      if var2 == 6 then return true end
-      return var2 == 17
+   local v1 = cast("uint16_t*", P+12)[0]
+   if v1 == 8 then
+      local v2 = P[23]
+      if v2 == 1 then return true end
+      if v2 == 6 then return true end
+      return v2 == 17
    else
       if length < 54 then return false end
-      if var1 ~= 56710 then return false end
-      local var6 = P[20]
-      if var6 == 1 then return true end
+      if v1 ~= 56710 then return false end
+      local v3 = P[20]
+      if v3 == 1 then return true end
       if length < 55 then goto L19 end
       do
-         if var6 ~= 44 then goto L19 end
+         if v3 ~= 44 then goto L19 end
          if P[54] == 1 then return true end
          goto L19
       end
 ::L19::
-      if var6 == 6 then return true end
+      if v3 == 6 then return true end
       if length < 55 then goto L17 end
       do
-         if var6 ~= 44 then goto L17 end
+         if v3 ~= 44 then goto L17 end
          if P[54] == 6 then return true end
          goto L17
       end
 ::L17::
-      if var6 == 17 then return true end
+      if v3 == 17 then return true end
       if length < 55 then return false end
-      if var6 ~= 44 then return false end
+      if v3 ~= 44 then return false end
       return P[54] == 17
    end
 end

--- a/doc/icmp6-or-ip.md
+++ b/doc/icmp6-or-ip.md
@@ -53,10 +53,10 @@ return function(P,length)
    if length < 54 then goto L7 end
    do
       if cast("uint16_t*", P+12)[0] ~= 56710 then goto L7 end
-      local var2 = P[20]
-      if var2 == 58 then return true end
+      local v1 = P[20]
+      if v1 == 58 then return true end
       if length < 55 then goto L7 end
-      if var2 ~= 44 then goto L7 end
+      if v1 ~= 44 then goto L7 end
       if P[54] == 58 then return true end
       goto L7
    end

--- a/doc/icmp6.md
+++ b/doc/icmp6.md
@@ -47,10 +47,10 @@ local cast = require("ffi").cast
 return function(P,length)
    if length < 54 then return false end
    if cast("uint16_t*", P+12)[0] ~= 56710 then return false end
-   local var2 = P[20]
-   if var2 == 58 then return true end
+   local v1 = P[20]
+   if v1 == 58 then return true end
    if length < 55 then return false end
-   if var2 ~= 44 then return false end
+   if v1 ~= 44 then return false end
    return P[54] == 58
 end
 

--- a/doc/ip6-proto-47.md
+++ b/doc/ip6-proto-47.md
@@ -47,10 +47,10 @@ local cast = require("ffi").cast
 return function(P,length)
    if length < 54 then return false end
    if cast("uint16_t*", P+12)[0] ~= 56710 then return false end
-   local var2 = P[20]
-   if var2 == 47 then return true end
+   local v1 = P[20]
+   if v1 == 47 then return true end
    if length < 55 then return false end
-   if var2 ~= 44 then return false end
+   if v1 ~= 44 then return false end
    return P[54] == 47
 end
 

--- a/doc/ip6-proto-ah.md
+++ b/doc/ip6-proto-ah.md
@@ -47,10 +47,10 @@ local cast = require("ffi").cast
 return function(P,length)
    if length < 54 then return false end
    if cast("uint16_t*", P+12)[0] ~= 56710 then return false end
-   local var2 = P[20]
-   if var2 == 51 then return true end
+   local v1 = P[20]
+   if v1 == 51 then return true end
    if length < 55 then return false end
-   if var2 ~= 44 then return false end
+   if v1 ~= 44 then return false end
    return P[54] == 51
 end
 

--- a/doc/l1.md
+++ b/doc/l1.md
@@ -62,12 +62,12 @@ return function(P,length)
    if rshift(bswap(cast("uint16_t*", P+12)[0]), 16) > 1500 then return false end
    if cast("uint16_t*", P+14)[0] ~= 65278 then return false end
    if P[17] ~= 131 then return false end
-   local var5 = P[21]
-   if var5 == 15 then return true end
-   if var5 == 18 then return true end
-   if var5 == 24 then return true end
-   if var5 == 26 then return true end
-   return var5 == 17
+   local v1 = P[21]
+   if v1 == 15 then return true end
+   if v1 == 18 then return true end
+   if v1 == 24 then return true end
+   if v1 == 26 then return true end
+   return v1 == 17
 end
 
 ```

--- a/doc/net-127.0.0.0-8.md
+++ b/doc/net-127.0.0.0-8.md
@@ -70,15 +70,15 @@ local band = require("bit").band
 local cast = require("ffi").cast
 return function(P,length)
    if length < 34 then return false end
-   local var1 = cast("uint16_t*", P+12)[0]
-   if var1 == 8 then
+   local v1 = cast("uint16_t*", P+12)[0]
+   if v1 == 8 then
       if band(cast("uint32_t*", P+26)[0],255) == 127 then return true end
       return band(cast("uint32_t*", P+30)[0],255) == 127
    else
       if length < 42 then return false end
-      if var1 == 1544 then goto L12 end
+      if v1 == 1544 then goto L12 end
       do
-         if var1 == 13696 then goto L12 end
+         if v1 == 13696 then goto L12 end
          return false
       end
 ::L12::

--- a/doc/packet-access-igmp.md
+++ b/doc/packet-access-igmp.md
@@ -59,9 +59,9 @@ return function(P,length)
    if cast("uint16_t*", P+12)[0] ~= 8 then return false end
    if P[23] ~= 2 then return false end
    if band(cast("uint16_t*", P+20)[0],65311) ~= 0 then return false end
-   local var7 = lshift(band(P[14],15),2)
-   if (var7 + 23) > length then return false end
-   return P[(var7 + 22)] < 8
+   local v1 = lshift(band(P[14],15),2)
+   if (v1 + 23) > length then return false end
+   return P[(v1 + 22)] < 8
 end
 
 ```

--- a/doc/packet-access-igrp.md
+++ b/doc/packet-access-igrp.md
@@ -59,9 +59,9 @@ return function(P,length)
    if cast("uint16_t*", P+12)[0] ~= 8 then return false end
    if P[23] ~= 9 then return false end
    if band(cast("uint16_t*", P+20)[0],65311) ~= 0 then return false end
-   local var7 = lshift(band(P[14],15),2)
-   if (var7 + 23) > length then return false end
-   return P[(var7 + 22)] < 8
+   local v1 = lshift(band(P[14],15),2)
+   if (v1 + 23) > length then return false end
+   return P[(v1 + 22)] < 8
 end
 
 ```

--- a/doc/packet-access-pim.md
+++ b/doc/packet-access-pim.md
@@ -59,9 +59,9 @@ return function(P,length)
    if cast("uint16_t*", P+12)[0] ~= 8 then return false end
    if P[23] ~= 103 then return false end
    if band(cast("uint16_t*", P+20)[0],65311) ~= 0 then return false end
-   local var7 = lshift(band(P[14],15),2)
-   if (var7 + 23) > length then return false end
-   return P[(var7 + 22)] < 8
+   local v1 = lshift(band(P[14],15),2)
+   if (v1 + 23) > length then return false end
+   return P[(v1 + 22)] < 8
 end
 
 ```

--- a/doc/packet-access-sctp.md
+++ b/doc/packet-access-sctp.md
@@ -59,9 +59,9 @@ return function(P,length)
    if cast("uint16_t*", P+12)[0] ~= 8 then return false end
    if P[23] ~= 132 then return false end
    if band(cast("uint16_t*", P+20)[0],65311) ~= 0 then return false end
-   local var7 = lshift(band(P[14],15),2)
-   if (var7 + 23) > length then return false end
-   return P[(var7 + 22)] < 8
+   local v1 = lshift(band(P[14],15),2)
+   if (v1 + 23) > length then return false end
+   return P[(v1 + 22)] < 8
 end
 
 ```

--- a/doc/packet-access-vrrp.md
+++ b/doc/packet-access-vrrp.md
@@ -59,9 +59,9 @@ return function(P,length)
    if cast("uint16_t*", P+12)[0] ~= 8 then return false end
    if P[23] ~= 112 then return false end
    if band(cast("uint16_t*", P+20)[0],65311) ~= 0 then return false end
-   local var7 = lshift(band(P[14],15),2)
-   if (var7 + 23) > length then return false end
-   return P[(var7 + 22)] < 8
+   local v1 = lshift(band(P[14],15),2)
+   if (v1 + 23) > length then return false end
+   return P[(v1 + 22)] < 8
 end
 
 ```

--- a/doc/portrange-0-6000.md
+++ b/doc/portrange-0-6000.md
@@ -103,44 +103,44 @@ local lshift = require("bit").lshift
 local band = require("bit").band
 return function(P,length)
    if length < 34 then return false end
-   local var1 = cast("uint16_t*", P+12)[0]
-   if var1 == 8 then
-      local var2 = P[23]
-      if var2 == 6 then goto L8 end
+   local v1 = cast("uint16_t*", P+12)[0]
+   if v1 == 8 then
+      local v2 = P[23]
+      if v2 == 6 then goto L8 end
       do
-         if var2 == 17 then goto L8 end
-         if var2 == 132 then goto L8 end
+         if v2 == 17 then goto L8 end
+         if v2 == 132 then goto L8 end
          return false
       end
 ::L8::
       if band(cast("uint16_t*", P+20)[0],65311) ~= 0 then return false end
-      local var9 = lshift(band(P[14],15),2)
-      local var10 = (var9 + 16)
-      if var10 > length then return false end
-      if rshift(bswap(cast("uint16_t*", P+(var9 + 14))[0]), 16) <= 6000 then return true end
-      if (var9 + 18) > length then return false end
-      return rshift(bswap(cast("uint16_t*", P+var10)[0]), 16) <= 6000
+      local v3 = lshift(band(P[14],15),2)
+      local v4 = (v3 + 16)
+      if v4 > length then return false end
+      if rshift(bswap(cast("uint16_t*", P+(v3 + 14))[0]), 16) <= 6000 then return true end
+      if (v3 + 18) > length then return false end
+      return rshift(bswap(cast("uint16_t*", P+v4)[0]), 16) <= 6000
    else
       if length < 56 then return false end
-      if var1 ~= 56710 then return false end
-      local var28 = P[20]
-      if var28 == 6 then goto L26 end
+      if v1 ~= 56710 then return false end
+      local v5 = P[20]
+      if v5 == 6 then goto L26 end
       do
-         if var28 ~= 44 then goto L29 end
+         if v5 ~= 44 then goto L29 end
          do
             if P[54] == 6 then goto L26 end
             goto L29
          end
 ::L29::
-         if var28 == 17 then goto L26 end
-         if var28 ~= 44 then goto L35 end
+         if v5 == 17 then goto L26 end
+         if v5 ~= 44 then goto L35 end
          do
             if P[54] == 17 then goto L26 end
             goto L35
          end
 ::L35::
-         if var28 == 132 then goto L26 end
-         if var28 ~= 44 then return false end
+         if v5 == 132 then goto L26 end
+         if v5 ~= 44 then return false end
          if P[54] == 132 then goto L26 end
          return false
       end

--- a/doc/proto-47.md
+++ b/doc/proto-47.md
@@ -55,19 +55,19 @@ end
 local cast = require("ffi").cast
 return function(P,length)
    if length < 34 then return false end
-   local var1 = cast("uint16_t*", P+12)[0]
-   if var1 ~= 8 then goto L7 end
+   local v1 = cast("uint16_t*", P+12)[0]
+   if v1 ~= 8 then goto L7 end
    do
       if P[23] == 47 then return true end
       goto L7
    end
 ::L7::
    if length < 54 then return false end
-   if var1 ~= 56710 then return false end
-   local var4 = P[20]
-   if var4 == 47 then return true end
+   if v1 ~= 56710 then return false end
+   local v2 = P[20]
+   if v2 == 47 then return true end
    if length < 55 then return false end
-   if var4 ~= 44 then return false end
+   if v2 ~= 44 then return false end
    return P[54] == 47
 end
 

--- a/doc/sctp.md
+++ b/doc/sctp.md
@@ -55,16 +55,16 @@ end
 local cast = require("ffi").cast
 return function(P,length)
    if length < 34 then return false end
-   local var1 = cast("uint16_t*", P+12)[0]
-   if var1 == 8 then
+   local v1 = cast("uint16_t*", P+12)[0]
+   if v1 == 8 then
       return P[23] == 132
    end
    if length < 54 then return false end
-   if var1 ~= 56710 then return false end
-   local var4 = P[20]
-   if var4 == 132 then return true end
+   if v1 ~= 56710 then return false end
+   local v2 = P[20]
+   if v2 == 132 then return true end
    if length < 55 then return false end
-   if var4 ~= 44 then return false end
+   if v2 ~= 44 then return false end
    return P[54] == 132
 end
 

--- a/doc/src-host-192.68.1.1-and-less-100.md
+++ b/doc/src-host-192.68.1.1-and-less-100.md
@@ -55,15 +55,15 @@ end
 local cast = require("ffi").cast
 return function(P,length)
    if length < 34 then return false end
-   local var1 = cast("uint16_t*", P+12)[0]
-   if var1 == 8 then
+   local v1 = cast("uint16_t*", P+12)[0]
+   if v1 == 8 then
       if cast("uint32_t*", P+26)[0] == 16860352 then goto L6 end
       goto L7
    else
       if length < 42 then return false end
-      if var1 == 1544 then goto L12 end
+      if v1 == 1544 then goto L12 end
       do
-         if var1 == 13696 then goto L12 end
+         if v1 == 13696 then goto L12 end
          return false
       end
 ::L12::

--- a/doc/src-port-80.md
+++ b/doc/src-port-80.md
@@ -81,41 +81,41 @@ local band = require("bit").band
 local cast = require("ffi").cast
 return function(P,length)
    if length < 34 then return false end
-   local var1 = cast("uint16_t*", P+12)[0]
-   if var1 == 8 then
-      local var2 = P[23]
-      if var2 == 6 then goto L8 end
+   local v1 = cast("uint16_t*", P+12)[0]
+   if v1 == 8 then
+      local v2 = P[23]
+      if v2 == 6 then goto L8 end
       do
-         if var2 == 17 then goto L8 end
-         if var2 == 132 then goto L8 end
+         if v2 == 17 then goto L8 end
+         if v2 == 132 then goto L8 end
          return false
       end
 ::L8::
       if band(cast("uint16_t*", P+20)[0],65311) ~= 0 then return false end
-      local var9 = lshift(band(P[14],15),2)
-      if (var9 + 16) > length then return false end
-      return cast("uint16_t*", P+(var9 + 14))[0] == 20480
+      local v3 = lshift(band(P[14],15),2)
+      if (v3 + 16) > length then return false end
+      return cast("uint16_t*", P+(v3 + 14))[0] == 20480
    else
       if length < 56 then return false end
-      if var1 ~= 56710 then return false end
-      local var17 = P[20]
-      if var17 == 6 then goto L22 end
+      if v1 ~= 56710 then return false end
+      local v4 = P[20]
+      if v4 == 6 then goto L22 end
       do
-         if var17 ~= 44 then goto L25 end
+         if v4 ~= 44 then goto L25 end
          do
             if P[54] == 6 then goto L22 end
             goto L25
          end
 ::L25::
-         if var17 == 17 then goto L22 end
-         if var17 ~= 44 then goto L31 end
+         if v4 == 17 then goto L22 end
+         if v4 ~= 44 then goto L31 end
          do
             if P[54] == 17 then goto L22 end
             goto L31
          end
 ::L31::
-         if var17 == 132 then goto L22 end
-         if var17 ~= 44 then return false end
+         if v4 == 132 then goto L22 end
+         if v4 ~= 44 then return false end
          if P[54] == 132 then goto L22 end
          return false
       end

--- a/doc/tcp-address.md
+++ b/doc/tcp-address.md
@@ -25,10 +25,10 @@ return function(P,length)
    if cast("uint16_t*", P+12)[0] ~= 8 then return false end
    if P[23] ~= 6 then return false end
    if band(cast("uint16_t*", P+20)[0],65311) ~= 0 then return false end
-   local var7 = lshift(band(P[14],15),2)
-   if (var7 + 15) > length then return false end
-   local var13 = P[(var7 + 14)]
-   return var13 == var13
+   local v1 = lshift(band(P[14],15),2)
+   if (v1 + 15) > length then return false end
+   local v2 = P[(v1 + 14)]
+   return v2 == v2
 end
 
 ```

--- a/doc/tcp-port-80.md
+++ b/doc/tcp-port-80.md
@@ -82,23 +82,23 @@ local band = require("bit").band
 local cast = require("ffi").cast
 return function(P,length)
    if length < 34 then return false end
-   local var1 = cast("uint16_t*", P+12)[0]
-   if var1 == 8 then
+   local v1 = cast("uint16_t*", P+12)[0]
+   if v1 == 8 then
       if P[23] ~= 6 then return false end
       if band(cast("uint16_t*", P+20)[0],65311) ~= 0 then return false end
-      local var7 = lshift(band(P[14],15),2)
-      local var8 = (var7 + 16)
-      if var8 > length then return false end
-      if cast("uint16_t*", P+(var7 + 14))[0] == 20480 then return true end
-      if (var7 + 18) > length then return false end
-      return cast("uint16_t*", P+var8)[0] == 20480
+      local v2 = lshift(band(P[14],15),2)
+      local v3 = (v2 + 16)
+      if v3 > length then return false end
+      if cast("uint16_t*", P+(v2 + 14))[0] == 20480 then return true end
+      if (v2 + 18) > length then return false end
+      return cast("uint16_t*", P+v3)[0] == 20480
    else
       if length < 56 then return false end
-      if var1 ~= 56710 then return false end
-      local var24 = P[20]
-      if var24 == 6 then goto L22 end
+      if v1 ~= 56710 then return false end
+      local v4 = P[20]
+      if v4 == 6 then goto L22 end
       do
-         if var24 ~= 44 then return false end
+         if v4 ~= 44 then return false end
          if P[54] == 6 then goto L22 end
          return false
       end


### PR DESCRIPTION
* src/pf/anf.lua: Renumber vars before lowering to CPS, for better
  readability.

This one probably conflicts with "optimize pfmatch".  I can regenerate the .md files when that lands, or vice versa.