### PR TITLE
tests/Makefile: finish download before running tests (fixes #244)

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -12,7 +12,9 @@ PFLUA_QUICKCHECK=$(ABS_TOP_SRCDIR)/tools/pflua-quickcheck
 all:
 	@true
 
-check: regression quickcheck
+check:
+	$(MAKE) $(TEST_SAVEFILE)
+	$(MAKE) regression quickcheck
 	./test-matches data
 	# Make sure PF_VERBOSE isn't causing crashes
 	PF_VERBOSE=1 $(ABS_TOP_SRCDIR)/tools/pflua-compile "ip" >/dev/null 2>&1
@@ -20,7 +22,8 @@ check: regression quickcheck
 $(TEST_SAVEFILE):
 	wget --output-document $@ $(TEST_SAVEFILE_URL)
 
-quickcheck: $(TEST_SAVEFILE)
+quickcheck:
+	$(MAKE) $(TEST_SAVEFILE)
 	$(PFLUA_QUICKCHECK) properties/repeatable_randomization
 	$(PFLUA_QUICKCHECK) properties/pflua_math_eq_libpcap_math
 	$(PFLUA_QUICKCHECK) --iterations=100 properties/pflua_pipelines_match $(TEST_SAVEFILE)
@@ -30,13 +33,17 @@ quickcheck: $(TEST_SAVEFILE)
 
 regression: pflang_regression_tests ir_regression_tests
 
-ir_regression_tests: $(TEST_SAVEFILE) $(IR_REGRESSION_TESTS)
+ir_regression_tests:
+	$(MAKE) $(TEST_SAVEFILE)
+	$(MAKE) $(IR_REGRESSION_TESTS)
 
 .PHONY: $(IR_REGRESSION_TESTS)
 $(IR_REGRESSION_TESTS):
 	./$@
 
-pflang_regression_tests: $(TEST_SAVEFILE) $(PFLANG_REGRESSION_TESTS)
+pflang_regression_tests:
+	$(MAKE) $(TEST_SAVEFILE)
+	$(MAKE) $(PFLANG_REGRESSION_TESTS)
 
 .PHONY: $(PFLANG_REGRESSION_TESTS)
 $(PFLANG_REGRESSION_TESTS):


### PR DESCRIPTION
With parallel builds enabled (e.g. via `make -j 4 check` or
MAKEFLAGS set to '-j 4'), the "tests" makefile schedules the download of
data/wingolog.pcap in parallel with the tests that depend on that file
(issue #244). This commit restricts the parallelism in tests/Makefile to
prevent this.

The following targets in tests/Makefile depend on data/wingolog.pcap:

* check (via quickcheck, regression and its own rule)
* quickcheck (via its own rules)
* regression (via pflang_regression_tests and ir_regression_tests)
* ir_regression_tests (via $IR_REGRESSION_TESTS)
* pflang_regression_tests (via $PFLANG_REGRESSION_TESTS)

With parallel builds enabled, prior to this commit `make $TARGET` with
$TARGET set to any of the targets listed above is likely to fail if
data/wingolog.pcap has not been downloaded yet.

Using a trick taken from http://stackoverflow.com/a/8496739/3507119 the
download is forced to happen before any of the rules of the above
targets are executed. Instead of listing the download target
$TEST_SAVEFILE_URL as a prerequisite, the command

	$(MAKE) $(TEST_SAVEFILE_URL)

has been prepended to each of the targets listed above. Now any of them
can be executed with parallel builds enabled.

I did not prepend this command to the rule for $IR_REGRESSION_TESTS and
$PFLANG_REGRESSION_TESTS because that seemed like overkill. Anyone who
executes a particular regression test directly probably already has
data/wingolog.pcap or will be able to read the error message that comes
up when that file is missing.