### PR TITLE
Support `src <address>` and `dst <address>`

### DIFF
--- a/src/pf/expand.lua
+++ b/src/pf/expand.lua
@@ -847,10 +847,12 @@ local function expand_psnp(expr)
 end
 
 local primitive_expanders = {
+   dst = expand_dst_host,
    dst_host = expand_dst_host,
    dst_net = expand_dst_net,
    dst_port = expand_dst_port,
    dst_portrange = expand_dst_portrange,
+   src = expand_src_host,
    src_host = expand_src_host,
    src_net = expand_src_net,
    src_port = expand_src_port,
@@ -1232,6 +1234,8 @@ function selftest ()
                    { '=', { '[]', { '+', 0, 0 }, 1 }, 2 },
                    { 'fail' } },
       expand(parse("ether[0] = 2"), 'EN10MB'))
+   assert_equals(expand(parse("src 1::ff11"), 'EN10MB'),
+      expand(parse("src host 1::ff11"), 'EN10MB'))
    -- Could check this, but it's very large
    expand(parse("tcp port 80 and (((ip[2:2] - ((ip[0]&0xf)<<2)) - ((tcp[12]&0xf0)>>2)) != 0)"),
           "EN10MB")

--- a/src/pf/parse.lua
+++ b/src/pf/parse.lua
@@ -776,8 +776,8 @@ function parse_arithmetic(lexer, tok, max_precedence, parsed_exp)
 end
 
 local primitives = {
-   dst = table_parser(src_or_dst_types),
-   src = table_parser(src_or_dst_types),
+   dst = table_parser(src_or_dst_types, unary(parse_host_arg)),
+   src = table_parser(src_or_dst_types, unary(parse_host_arg)),
    host = unary(parse_host_arg),
    ether = table_parser(ether_types),
    fddi = table_parser(ether_types),
@@ -1046,6 +1046,10 @@ function selftest ()
               { 'host', '0xffffffffff-oo.com' })
    parse_test("src host 127.0.0.1",
               { 'src_host', { 'ipv4', 127, 0, 0, 1 } })
+   parse_test("src 127.0.0.1",
+              { 'src', { 'ipv4', 127, 0, 0, 1 } })
+   parse_test("dst 1::ff11",
+              { 'dst', { 'ipv6', 1, 0, 0, 0, 0, 0, 0, 65297 } })
    parse_test("src net 10.0.0.0/24",
               { 'src_net',
                 { 'ipv4/len', { 'ipv4', 10, 0, 0, 0 }, 24 }})


### PR DESCRIPTION
Equivalent to `src host <address>` and `dst host <address>`. Fixes #248.