### PR TITLE
Add more tests and fix issue #252

### DIFF
--- a/src/pf/backend.lua
+++ b/src/pf/backend.lua
@@ -288,7 +288,7 @@ local function serialize(builder, stmt)
    end
 
    local function serialize_call(expr)
-      local args = { 'P', 'len' }
+      local args = { 'P', 'length' }
       for i=3,#expr do table.insert(args, serialize_value(expr[i])) end
       return 'self.'..expr[2]..'('..table.concat(args, ', ')..')'
    end

--- a/src/pf/match.lua
+++ b/src/pf/match.lua
@@ -303,7 +303,7 @@ function compile(str, opts)
    expr = anf.convert_anf(expr)
    expr = ssa.convert_ssa(expr)
    if opts.source then return backend.emit_match_lua(expr) end
-   return backend.emit_and_load_match(expr, filter_str)
+   return backend.emit_and_load_match(expr, str)
 end
 
 function selftest()

--- a/src/pf/match.lua
+++ b/src/pf/match.lua
@@ -362,5 +362,27 @@ function selftest()
    end
    test("match { tcp port 80 => pass }")
 
+   local function test(str, pkt, obj)
+      -- Try calling the matching method on the given table
+      -- which should have handlers installed
+      obj.match = compile(str)
+      obj:match(pkt.packet, pkt.len)
+   end
+
+   local savefile = require("pf.savefile")
+   pkts = savefile.load_packets("../tests/data/arp.pcap")
+
+   test("match { tcp port 80 => pass }",
+        pkts[1],
+        -- the handler shouldn't be called
+        { pass = function (pkt, len) assert(false) end })
+   test("match { arp => handle(&arp[1:1]) }",
+        pkts[1],
+        { handle = function (pkt, len, off)
+                     utils.assert(pkt ~= nil)
+                     utils.assert(len ~= nil)
+                     utils.assert_equals(off, 15)
+                   end })
+
    print("OK")
 end

--- a/src/pf/match.lua
+++ b/src/pf/match.lua
@@ -356,7 +356,7 @@ function selftest()
    test("match { otherwise => x(1/0) }",
         { 'fail' })
 
-   local function test(str, expr)
+   local function test(str)
       -- Just a test to see if it works without errors.
       compile(str)
    end

--- a/tools/pflua-compile
+++ b/tools/pflua-compile
@@ -10,7 +10,7 @@ local utils = require("pf.utils")
 
 function usage()
    local content = [=[
-Usage: pflua-compile [-O0] [--bpf-asm | --bpf-lua | --lua] <expression>
+Usage: pflua-compile [-O0] [--bpf-asm | --bpf-lua | --lua | --match] <expression>
 
 Options:
    --bpf-asm   Print libpcap-generated BPF asm code for the pflang <expression>


### PR DESCRIPTION
Adds some more unit tests for pfmatch that execute filters (it hardcodes a path to the data directory for the tests, is that ok?) and should fix issue #252. Also includes a minor fix to the usage printout for `pflua-compile`.