### PR TITLE
Use method invocation for pfmatch handler calls

### DIFF
--- a/src/pf/backend.lua
+++ b/src/pf/backend.lua
@@ -290,7 +290,7 @@ local function serialize(builder, stmt)
    local function serialize_call(expr)
       local args = { 'P', 'length' }
       for i=3,#expr do table.insert(args, serialize_value(expr[i])) end
-      return 'self.'..expr[2]..'('..table.concat(args, ', ')..')'
+      return 'self:'..expr[2]..'('..table.concat(args, ', ')..')'
    end
 
    local serialize_statement

--- a/src/pf/match.lua
+++ b/src/pf/match.lua
@@ -375,10 +375,11 @@ function selftest()
    test("match { tcp port 80 => pass }",
         pkts[1],
         -- the handler shouldn't be called
-        { pass = function (pkt, len) assert(false) end })
+        { pass = function (self, pkt, len) assert(false) end })
    test("match { arp => handle(&arp[1:1]) }",
         pkts[1],
-        { handle = function (pkt, len, off)
+        { handle = function (self, pkt, len, off)
+                     utils.assert(self ~= nil)
                      utils.assert(pkt ~= nil)
                      utils.assert(len ~= nil)
                      utils.assert_equals(off, 15)


### PR DESCRIPTION
This fixes a potential pfmatch design issue I mentioned briefly to @wingo in St. Louis. When you compile a pfmatch expression like this:

```
$ ../tools/pflua-compile --match "match { ip => handler }"
local cast = require("ffi").cast
return function(self,P,length)
   if length < 14 then return false end
   if cast("uint16_t*", P+12)[0] == 8 then return self.handler(P, length) end
   return false
end
```

The resulting handler call looks like `self.handler(P, length)` which doesn't pass the `self` parameter along. Compiling the call to `self:handler(P, length)` would probably be more useful so that you can pass state to the handler methods.

(note: this PR depends on PR #253 --- only commit a3cff6f is new to this branch)