### PR TITLE
Fix 'proto' operation

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -33,6 +33,7 @@ EXAMPLES = \
 	iso-proto-47.md \
 	ip-proto-sctp.md \
 	proto-47.md \
+	proto-sctp.md \
 	decnet-src-10.15.md \
 	decnet-host-10.15.md \
 	l1.md \
@@ -155,6 +156,9 @@ ip-proto-sctp.md: $(PFLUA)
 
 proto-47.md: $(PFLUA)
 	../tools/dump-markdown "proto 47" > $@.tmp && mv $@.tmp $@
+
+proto-sctp.md: $(PFLUA)
+	../tools/dump-markdown "proto \sctp" > $@.tmp && mv $@.tmp $@
 
 decnet-src-10.15.md: $(PFLUA)
 	../tools/dump-markdown "decnet src 10.15" > $@.tmp && mv $@.tmp $@

--- a/doc/proto-sctp.md
+++ b/doc/proto-sctp.md
@@ -24,26 +24,26 @@
 ```
 return function (P, length)
    local A = 0
-   if 14 > length then return 0 end
+   if 14 > length then return false end
    A = bit.bor(bit.lshift(P[12], 8), P[12+1])
    if not (A==2048) then goto L3 end
-   if 24 > length then return 0 end
+   if 24 > length then return false end
    A = P[23]
    if (A==132) then goto L9 end
    goto L10
    ::L3::
    if not (A==34525) then goto L10 end
-   if 21 > length then return 0 end
+   if 21 > length then return false end
    A = P[20]
    if (A==132) then goto L9 end
    if not (A==44) then goto L10 end
-   if 55 > length then return 0 end
+   if 55 > length then return false end
    A = P[54]
    if not (A==132) then goto L10 end
    ::L9::
-   do return 65535 end
+   do return true end
    ::L10::
-   do return 0 end
+   do return false end
    error("end of bpf")
 end
 ```
@@ -52,16 +52,56 @@ end
 ## Direct pflang compilation
 
 ```
+local cast = require("ffi").cast
 return function(P,length)
-   if not (length >= 34) then do return false end end
+   if length < 34 then return false end
+   local v1 = cast("uint16_t*", P+12)[0]
+   if v1 ~= 8 then goto L7 end
    do
-      local v1 = ffi.cast("uint16_t*", P+12)[0]
-      if not (v1 == 8) then do return false end end
-      do
-         local v2 = P[23]
-         do return v2 == 132 end
-      end
+      if P[23] == 132 then return true end
+      goto L7
    end
+::L7::
+   if length < 54 then return false end
+   if v1 ~= 56710 then return false end
+   local v2 = P[20]
+   if v2 == 132 then return true end
+   if length < 55 then return false end
+   if v2 ~= 44 then return false end
+   return P[54] == 132
 end
+
+```
+
+## Native pflang compilation
+
+```
+7fc73f3c2000  4883FE22          cmp rsi, +0x22
+7fc73f3c2004  7C4C              jl 0x7fc73f3c2052
+7fc73f3c2006  0FB7470C          movzx eax, word [rdi+0xc]
+7fc73f3c200a  4883F808          cmp rax, +0x08
+7fc73f3c200e  750D              jnz 0x7fc73f3c201d
+7fc73f3c2010  0FB64F17          movzx ecx, byte [rdi+0x17]
+7fc73f3c2014  4881F984000000    cmp rcx, 0x84
+7fc73f3c201b  7438              jz 0x7fc73f3c2055
+7fc73f3c201d  4883FE36          cmp rsi, +0x36
+7fc73f3c2021  7C2F              jl 0x7fc73f3c2052
+7fc73f3c2023  4881F886DD0000    cmp rax, 0xdd86
+7fc73f3c202a  7526              jnz 0x7fc73f3c2052
+7fc73f3c202c  0FB64714          movzx eax, byte [rdi+0x14]
+7fc73f3c2030  4881F884000000    cmp rax, 0x84
+7fc73f3c2037  741C              jz 0x7fc73f3c2055
+7fc73f3c2039  4883FE37          cmp rsi, +0x37
+7fc73f3c203d  7C13              jl 0x7fc73f3c2052
+7fc73f3c203f  4883F82C          cmp rax, +0x2c
+7fc73f3c2043  750D              jnz 0x7fc73f3c2052
+7fc73f3c2045  0FB64736          movzx eax, byte [rdi+0x36]
+7fc73f3c2049  4881F884000000    cmp rax, 0x84
+7fc73f3c2050  7403              jz 0x7fc73f3c2055
+7fc73f3c2052  B000              mov al, 0x0
+7fc73f3c2054  C3                ret
+7fc73f3c2055  B001              mov al, 0x1
+7fc73f3c2057  C3                ret
+
 ```
 

--- a/src/pf/expand.lua
+++ b/src/pf/expand.lua
@@ -1205,7 +1205,7 @@ function expand_bool(expr, dlt)
       local expander = primitive_expanders[expr[1]]
       assert(expander, "unimplemented primitive: "..expr[1])
       local expanded = expander(expr, dlt)
-      return expand_bool(expander(expr, dlt), dlt)
+      return expand_bool(expanded, dlt)
    end
 end
 

--- a/src/pf/expand.lua
+++ b/src/pf/expand.lua
@@ -459,7 +459,7 @@ local function expand_ip6_proto(expr)
 end
 
 local function expand_ip_proto(expr)
-   return { 'or', has_ipv4_protocol(expr[2]), has_ipv6_protocol(expr[2]) }
+   return { 'or', expand_ip4_proto(expr), expand_ip6_proto(expr) }
 end
 
 -- ISO
@@ -1236,6 +1236,10 @@ function selftest ()
       expand(parse("ether[0] = 2"), 'EN10MB'))
    assert_equals(expand(parse("src 1::ff11"), 'EN10MB'),
       expand(parse("src host 1::ff11"), 'EN10MB'))
+   assert_equals(expand(parse("proto \\sctp"), 'EN10MB'),
+      expand(parse("ip proto \\sctp or ip6 proto \\sctp"), 'EN10MB'))
+   assert_equals(expand(parse("proto \\tcp"), 'EN10MB'),
+      expand(parse("ip proto \\tcp or ip6 proto \\tcp"), 'EN10MB'))
    -- Could check this, but it's very large
    expand(parse("tcp port 80 and (((ip[2:2] - ((ip[0]&0xf)<<2)) - ((tcp[12]&0xf0)>>2)) != 0)"),
           "EN10MB")


### PR DESCRIPTION
It looks like at some point the `proto` operation broke in pflua. I've added some tests for it and added a fix.

This also updates the `proto \sctp` example. I was less sure about this part so please let me know if I didn't do the update quite right.

Related to issue #255 
