### PR TITLE
Add regression test for PR#250

### DIFF
--- a/src/pf.lua
+++ b/src/pf.lua
@@ -88,5 +88,7 @@ function selftest ()
    assert_count('tcp', v4, 41)
    assert_count('tcp port 80', v4, 41)
 
+   compile_filter("ip[0] * ip[1] = 4", { bpf=true })
+
    print("OK")
 end


### PR DESCRIPTION
Adds @mpeterv test case as regression test for #250.

The test case crashed BPF compilation pipeline before #250 fix.

```
luajit: ./pf/bpf.lua:65: attempt to compare string with number
stack traceback:
        ./pf/bpf.lua:65: in function 'runtime_u32'
        ./pf/bpf.lua:98: in function 'is_power_of_2'
        ./pf/bpf.lua:253: in function 'alu'
        ./pf/bpf.lua:327: in function 'compile_lua'
        ./pf/bpf.lua:444: in function 'compile_filter'
        ./pf.lua:92: in function 'test_attempt_to_compare_string_with_a_number'
        ./pf.lua:94: in function 'selftest'
        (command line):1: in main chunk
        [C]: at 0x004043b0
```