### PR TITLE
Fix tcp-address.md

### DIFF
--- a/doc/decnet-host-10.15.md
+++ b/doc/decnet-host-10.15.md
@@ -162,63 +162,61 @@ return function(P,length)
       end
    end
 end
-
 ```
 
 ## Native pflang compilation
 
 ```
-7f6675f0d000  4883FE15          cmp rsi, +0x15
-7f6675f0d004  0F8CC4000000      jl 0x7f6675f0d0ce
-7f6675f0d00a  0FB64710          movzx eax, byte [rdi+0x10]
-7f6675f0d00e  4883E007          and rax, +0x07
-7f6675f0d012  4883F802          cmp rax, +0x02
-7f6675f0d016  7527              jnz 0x7f6675f0d03f
-7f6675f0d018  0FB74F13          movzx ecx, word [rdi+0x13]
-7f6675f0d01c  4881F90A0F0000    cmp rcx, 0xf0a
-7f6675f0d023  0F84A8000000      jz 0x7f6675f0d0d1
-7f6675f0d029  0FB74F11          movzx ecx, word [rdi+0x11]
-7f6675f0d02d  4881F90A0F0000    cmp rcx, 0xf0a
-7f6675f0d034  0F8497000000      jz 0x7f6675f0d0d1
-7f6675f0d03a  E98F000000        jmp 0x7f6675f0d0ce
-7f6675f0d03f  4883FE16          cmp rsi, +0x16
-7f6675f0d043  0F8C85000000      jl 0x7f6675f0d0ce
-7f6675f0d049  0FB74F10          movzx ecx, word [rdi+0x10]
-7f6675f0d04d  4881E1FF070000    and rcx, 0x7ff
-7f6675f0d054  4881F981020000    cmp rcx, 0x281
-7f6675f0d05b  7520              jnz 0x7f6675f0d07d
-7f6675f0d05d  0FB75714          movzx edx, word [rdi+0x14]
-7f6675f0d061  4881FA0A0F0000    cmp rdx, 0xf0a
-7f6675f0d068  0F8463000000      jz 0x7f6675f0d0d1
-7f6675f0d06e  0FB75712          movzx edx, word [rdi+0x12]
-7f6675f0d072  4881FA0A0F0000    cmp rdx, 0xf0a
-7f6675f0d079  7456              jz 0x7f6675f0d0d1
-7f6675f0d07b  EB51              jmp 0x7f6675f0d0ce
-7f6675f0d07d  4883FE21          cmp rsi, +0x21
-7f6675f0d081  7C4B              jl 0x7f6675f0d0ce
-7f6675f0d083  4883F806          cmp rax, +0x06
-7f6675f0d087  751C              jnz 0x7f6675f0d0a5
-7f6675f0d089  0FB7471F          movzx eax, word [rdi+0x1f]
-7f6675f0d08d  4881F80A0F0000    cmp rax, 0xf0a
-7f6675f0d094  743B              jz 0x7f6675f0d0d1
-7f6675f0d096  0FB74717          movzx eax, word [rdi+0x17]
-7f6675f0d09a  4881F80A0F0000    cmp rax, 0xf0a
-7f6675f0d0a1  742E              jz 0x7f6675f0d0d1
-7f6675f0d0a3  EB29              jmp 0x7f6675f0d0ce
-7f6675f0d0a5  4883FE22          cmp rsi, +0x22
-7f6675f0d0a9  7C23              jl 0x7f6675f0d0ce
-7f6675f0d0ab  4881F981060000    cmp rcx, 0x681
-7f6675f0d0b2  751A              jnz 0x7f6675f0d0ce
-7f6675f0d0b4  0FB74F20          movzx ecx, word [rdi+0x20]
-7f6675f0d0b8  4881F90A0F0000    cmp rcx, 0xf0a
-7f6675f0d0bf  7410              jz 0x7f6675f0d0d1
-7f6675f0d0c1  0FB74F18          movzx ecx, word [rdi+0x18]
-7f6675f0d0c5  4881F90A0F0000    cmp rcx, 0xf0a
-7f6675f0d0cc  7403              jz 0x7f6675f0d0d1
-7f6675f0d0ce  B000              mov al, 0x0
-7f6675f0d0d0  C3                ret
-7f6675f0d0d1  B001              mov al, 0x1
-7f6675f0d0d3  C3                ret
-
+7f23529fe000  4883FE15          cmp rsi, +0x15
+7f23529fe004  0F8CC4000000      jl 0x7f23529fe0ce
+7f23529fe00a  0FB64710          movzx eax, byte [rdi+0x10]
+7f23529fe00e  4883E007          and rax, +0x07
+7f23529fe012  4883F802          cmp rax, +0x02
+7f23529fe016  7527              jnz 0x7f23529fe03f
+7f23529fe018  0FB74F13          movzx ecx, word [rdi+0x13]
+7f23529fe01c  4881F90A0F0000    cmp rcx, 0xf0a
+7f23529fe023  0F84A8000000      jz 0x7f23529fe0d1
+7f23529fe029  0FB74F11          movzx ecx, word [rdi+0x11]
+7f23529fe02d  4881F90A0F0000    cmp rcx, 0xf0a
+7f23529fe034  0F8497000000      jz 0x7f23529fe0d1
+7f23529fe03a  E98F000000        jmp 0x7f23529fe0ce
+7f23529fe03f  4883FE16          cmp rsi, +0x16
+7f23529fe043  0F8C85000000      jl 0x7f23529fe0ce
+7f23529fe049  0FB74F10          movzx ecx, word [rdi+0x10]
+7f23529fe04d  4881E1FF070000    and rcx, 0x7ff
+7f23529fe054  4881F981020000    cmp rcx, 0x281
+7f23529fe05b  7520              jnz 0x7f23529fe07d
+7f23529fe05d  0FB75714          movzx edx, word [rdi+0x14]
+7f23529fe061  4881FA0A0F0000    cmp rdx, 0xf0a
+7f23529fe068  0F8463000000      jz 0x7f23529fe0d1
+7f23529fe06e  0FB75712          movzx edx, word [rdi+0x12]
+7f23529fe072  4881FA0A0F0000    cmp rdx, 0xf0a
+7f23529fe079  7456              jz 0x7f23529fe0d1
+7f23529fe07b  EB51              jmp 0x7f23529fe0ce
+7f23529fe07d  4883FE21          cmp rsi, +0x21
+7f23529fe081  7C4B              jl 0x7f23529fe0ce
+7f23529fe083  4883F806          cmp rax, +0x06
+7f23529fe087  751C              jnz 0x7f23529fe0a5
+7f23529fe089  0FB7471F          movzx eax, word [rdi+0x1f]
+7f23529fe08d  4881F80A0F0000    cmp rax, 0xf0a
+7f23529fe094  743B              jz 0x7f23529fe0d1
+7f23529fe096  0FB74717          movzx eax, word [rdi+0x17]
+7f23529fe09a  4881F80A0F0000    cmp rax, 0xf0a
+7f23529fe0a1  742E              jz 0x7f23529fe0d1
+7f23529fe0a3  EB29              jmp 0x7f23529fe0ce
+7f23529fe0a5  4883FE22          cmp rsi, +0x22
+7f23529fe0a9  7C23              jl 0x7f23529fe0ce
+7f23529fe0ab  4881F981060000    cmp rcx, 0x681
+7f23529fe0b2  751A              jnz 0x7f23529fe0ce
+7f23529fe0b4  0FB74F20          movzx ecx, word [rdi+0x20]
+7f23529fe0b8  4881F90A0F0000    cmp rcx, 0xf0a
+7f23529fe0bf  7410              jz 0x7f23529fe0d1
+7f23529fe0c1  0FB74F18          movzx ecx, word [rdi+0x18]
+7f23529fe0c5  4881F90A0F0000    cmp rcx, 0xf0a
+7f23529fe0cc  7403              jz 0x7f23529fe0d1
+7f23529fe0ce  B000              mov al, 0x0
+7f23529fe0d0  C3                ret
+7f23529fe0d1  B001              mov al, 0x1
+7f23529fe0d3  C3                ret
 ```
 

--- a/doc/decnet-src-10.15.md
+++ b/doc/decnet-src-10.15.md
@@ -103,51 +103,49 @@ return function(P,length)
    if v2 ~= 1665 then return false end
    return cast("uint16_t*", P+32)[0] == 3850
 end
-
 ```
 
 ## Native pflang compilation
 
 ```
-7efd90ef8000  4883FE15          cmp rsi, +0x15
-7efd90ef8004  0F8C88000000      jl 0x7efd90ef8092
-7efd90ef800a  0FB64710          movzx eax, byte [rdi+0x10]
-7efd90ef800e  4883E007          and rax, +0x07
-7efd90ef8012  4883F802          cmp rax, +0x02
-7efd90ef8016  7516              jnz 0x7efd90ef802e
-7efd90ef8018  0FB74F13          movzx ecx, word [rdi+0x13]
-7efd90ef801c  4881F90A0F0000    cmp rcx, 0xf0a
-7efd90ef8023  0F846C000000      jz 0x7efd90ef8095
-7efd90ef8029  E964000000        jmp 0x7efd90ef8092
-7efd90ef802e  4883FE16          cmp rsi, +0x16
-7efd90ef8032  0F8C5A000000      jl 0x7efd90ef8092
-7efd90ef8038  0FB74F10          movzx ecx, word [rdi+0x10]
-7efd90ef803c  4881E1FF070000    and rcx, 0x7ff
-7efd90ef8043  4881F981020000    cmp rcx, 0x281
-7efd90ef804a  750F              jnz 0x7efd90ef805b
-7efd90ef804c  0FB75714          movzx edx, word [rdi+0x14]
-7efd90ef8050  4881FA0A0F0000    cmp rdx, 0xf0a
-7efd90ef8057  743C              jz 0x7efd90ef8095
-7efd90ef8059  EB37              jmp 0x7efd90ef8092
-7efd90ef805b  4883FE21          cmp rsi, +0x21
-7efd90ef805f  7C31              jl 0x7efd90ef8092
-7efd90ef8061  4883F806          cmp rax, +0x06
-7efd90ef8065  750F              jnz 0x7efd90ef8076
-7efd90ef8067  0FB7471F          movzx eax, word [rdi+0x1f]
-7efd90ef806b  4881F80A0F0000    cmp rax, 0xf0a
-7efd90ef8072  7421              jz 0x7efd90ef8095
-7efd90ef8074  EB1C              jmp 0x7efd90ef8092
-7efd90ef8076  4883FE22          cmp rsi, +0x22
-7efd90ef807a  7C16              jl 0x7efd90ef8092
-7efd90ef807c  4881F981060000    cmp rcx, 0x681
-7efd90ef8083  750D              jnz 0x7efd90ef8092
-7efd90ef8085  0FB74F20          movzx ecx, word [rdi+0x20]
-7efd90ef8089  4881F90A0F0000    cmp rcx, 0xf0a
-7efd90ef8090  7403              jz 0x7efd90ef8095
-7efd90ef8092  B000              mov al, 0x0
-7efd90ef8094  C3                ret
-7efd90ef8095  B001              mov al, 0x1
-7efd90ef8097  C3                ret
-
+7f3cc4529000  4883FE15          cmp rsi, +0x15
+7f3cc4529004  0F8C88000000      jl 0x7f3cc4529092
+7f3cc452900a  0FB64710          movzx eax, byte [rdi+0x10]
+7f3cc452900e  4883E007          and rax, +0x07
+7f3cc4529012  4883F802          cmp rax, +0x02
+7f3cc4529016  7516              jnz 0x7f3cc452902e
+7f3cc4529018  0FB74F13          movzx ecx, word [rdi+0x13]
+7f3cc452901c  4881F90A0F0000    cmp rcx, 0xf0a
+7f3cc4529023  0F846C000000      jz 0x7f3cc4529095
+7f3cc4529029  E964000000        jmp 0x7f3cc4529092
+7f3cc452902e  4883FE16          cmp rsi, +0x16
+7f3cc4529032  0F8C5A000000      jl 0x7f3cc4529092
+7f3cc4529038  0FB74F10          movzx ecx, word [rdi+0x10]
+7f3cc452903c  4881E1FF070000    and rcx, 0x7ff
+7f3cc4529043  4881F981020000    cmp rcx, 0x281
+7f3cc452904a  750F              jnz 0x7f3cc452905b
+7f3cc452904c  0FB75714          movzx edx, word [rdi+0x14]
+7f3cc4529050  4881FA0A0F0000    cmp rdx, 0xf0a
+7f3cc4529057  743C              jz 0x7f3cc4529095
+7f3cc4529059  EB37              jmp 0x7f3cc4529092
+7f3cc452905b  4883FE21          cmp rsi, +0x21
+7f3cc452905f  7C31              jl 0x7f3cc4529092
+7f3cc4529061  4883F806          cmp rax, +0x06
+7f3cc4529065  750F              jnz 0x7f3cc4529076
+7f3cc4529067  0FB7471F          movzx eax, word [rdi+0x1f]
+7f3cc452906b  4881F80A0F0000    cmp rax, 0xf0a
+7f3cc4529072  7421              jz 0x7f3cc4529095
+7f3cc4529074  EB1C              jmp 0x7f3cc4529092
+7f3cc4529076  4883FE22          cmp rsi, +0x22
+7f3cc452907a  7C16              jl 0x7f3cc4529092
+7f3cc452907c  4881F981060000    cmp rcx, 0x681
+7f3cc4529083  750D              jnz 0x7f3cc4529092
+7f3cc4529085  0FB74F20          movzx ecx, word [rdi+0x20]
+7f3cc4529089  4881F90A0F0000    cmp rcx, 0xf0a
+7f3cc4529090  7403              jz 0x7f3cc4529095
+7f3cc4529092  B000              mov al, 0x0
+7f3cc4529094  C3                ret
+7f3cc4529095  B001              mov al, 0x1
+7f3cc4529097  C3                ret
 ```
 

--- a/doc/dst-host-192.68.1.1-and-greater-100.md
+++ b/doc/dst-host-192.68.1.1-and-greater-100.md
@@ -67,32 +67,30 @@ return function(P,length)
 ::L8::
    return cast("uint32_t*", P+38)[0] == 16860352
 end
-
 ```
 
 ## Native pflang compilation
 
 ```
-7f435af62000  4883FE64          cmp rsi, +0x64
-7f435af62004  7C36              jl 0x7f435af6203c
-7f435af62006  0FB7770C          movzx esi, word [rdi+0xc]
-7f435af6200a  4883FE08          cmp rsi, +0x08
-7f435af6200e  750E              jnz 0x7f435af6201e
-7f435af62010  8B471E            mov eax, [rdi+0x1e]
-7f435af62013  4881F8C0440101    cmp rax, 0x010144c0
-7f435af6201a  7423              jz 0x7f435af6203f
-7f435af6201c  EB1E              jmp 0x7f435af6203c
-7f435af6201e  4881FE08060000    cmp rsi, 0x608
-7f435af62025  7409              jz 0x7f435af62030
-7f435af62027  4881FE80350000    cmp rsi, 0x3580
-7f435af6202e  750C              jnz 0x7f435af6203c
-7f435af62030  8B7726            mov esi, [rdi+0x26]
-7f435af62033  4881FEC0440101    cmp rsi, 0x010144c0
-7f435af6203a  7403              jz 0x7f435af6203f
-7f435af6203c  B000              mov al, 0x0
-7f435af6203e  C3                ret
-7f435af6203f  B001              mov al, 0x1
-7f435af62041  C3                ret
-
+7f5ab683b000  4883FE64          cmp rsi, +0x64
+7f5ab683b004  7C36              jl 0x7f5ab683b03c
+7f5ab683b006  0FB7770C          movzx esi, word [rdi+0xc]
+7f5ab683b00a  4883FE08          cmp rsi, +0x08
+7f5ab683b00e  750E              jnz 0x7f5ab683b01e
+7f5ab683b010  8B471E            mov eax, [rdi+0x1e]
+7f5ab683b013  4881F8C0440101    cmp rax, 0x010144c0
+7f5ab683b01a  7423              jz 0x7f5ab683b03f
+7f5ab683b01c  EB1E              jmp 0x7f5ab683b03c
+7f5ab683b01e  4881FE08060000    cmp rsi, 0x608
+7f5ab683b025  7409              jz 0x7f5ab683b030
+7f5ab683b027  4881FE80350000    cmp rsi, 0x3580
+7f5ab683b02e  750C              jnz 0x7f5ab683b03c
+7f5ab683b030  8B7726            mov esi, [rdi+0x26]
+7f5ab683b033  4881FEC0440101    cmp rsi, 0x010144c0
+7f5ab683b03a  7403              jz 0x7f5ab683b03f
+7f5ab683b03c  B000              mov al, 0x0
+7f5ab683b03e  C3                ret
+7f5ab683b03f  B001              mov al, 0x1
+7f5ab683b041  C3                ret
 ```
 

--- a/doc/dst-portrange-80-90.md
+++ b/doc/dst-portrange-80-90.md
@@ -131,81 +131,79 @@ return function(P,length)
       return v6 <= 90
    end
 end
-
 ```
 
 ## Native pflang compilation
 
 ```
-7f6f23ed9000  4883FE22          cmp rsi, +0x22
-7f6f23ed9004  0F8CFB000000      jl 0x7f6f23ed9105
-7f6f23ed900a  0FB7470C          movzx eax, word [rdi+0xc]
-7f6f23ed900e  4883F808          cmp rax, +0x08
-7f6f23ed9012  7576              jnz 0x7f6f23ed908a
-7f6f23ed9014  0FB64F17          movzx ecx, byte [rdi+0x17]
-7f6f23ed9018  4883F906          cmp rcx, +0x06
-7f6f23ed901c  7413              jz 0x7f6f23ed9031
-7f6f23ed901e  4883F911          cmp rcx, +0x11
-7f6f23ed9022  740D              jz 0x7f6f23ed9031
-7f6f23ed9024  4881F984000000    cmp rcx, 0x84
-7f6f23ed902b  0F85D4000000      jnz 0x7f6f23ed9105
-7f6f23ed9031  0FB74F14          movzx ecx, word [rdi+0x14]
-7f6f23ed9035  4881E11FFF0000    and rcx, 0xff1f
-7f6f23ed903c  4883F900          cmp rcx, +0x00
-7f6f23ed9040  0F85BF000000      jnz 0x7f6f23ed9105
-7f6f23ed9046  0FB64F0E          movzx ecx, byte [rdi+0xe]
-7f6f23ed904a  4883E10F          and rcx, +0x0f
-7f6f23ed904e  48C1E102          shl rcx, 0x02
-7f6f23ed9052  89CA              mov edx, ecx
-7f6f23ed9054  4883C212          add rdx, +0x12
-7f6f23ed9058  4839F2            cmp rdx, rsi
-7f6f23ed905b  0F8FA4000000      jg 0x7f6f23ed9105
-7f6f23ed9061  4883C110          add rcx, +0x10
-7f6f23ed9065  0FB70C0F          movzx ecx, word [rdi+rcx]
-7f6f23ed9069  66C1C908          ror cx, 0x08
-7f6f23ed906d  480FB7C9          movzx rcx, cx
-7f6f23ed9071  4883F950          cmp rcx, +0x50
-7f6f23ed9075  0F8C8A000000      jl 0x7f6f23ed9105
-7f6f23ed907b  4883F95A          cmp rcx, +0x5a
-7f6f23ed907f  0F8E83000000      jle 0x7f6f23ed9108
-7f6f23ed9085  E97B000000        jmp 0x7f6f23ed9105
-7f6f23ed908a  4883FE3A          cmp rsi, +0x3a
-7f6f23ed908e  0F8C71000000      jl 0x7f6f23ed9105
-7f6f23ed9094  4881F886DD0000    cmp rax, 0xdd86
-7f6f23ed909b  0F8564000000      jnz 0x7f6f23ed9105
-7f6f23ed90a1  0FB64714          movzx eax, byte [rdi+0x14]
-7f6f23ed90a5  4883F806          cmp rax, +0x06
-7f6f23ed90a9  7442              jz 0x7f6f23ed90ed
-7f6f23ed90ab  4883F82C          cmp rax, +0x2c
-7f6f23ed90af  750A              jnz 0x7f6f23ed90bb
-7f6f23ed90b1  0FB67736          movzx esi, byte [rdi+0x36]
-7f6f23ed90b5  4883FE06          cmp rsi, +0x06
-7f6f23ed90b9  7432              jz 0x7f6f23ed90ed
-7f6f23ed90bb  4883F811          cmp rax, +0x11
-7f6f23ed90bf  742C              jz 0x7f6f23ed90ed
-7f6f23ed90c1  4883F82C          cmp rax, +0x2c
-7f6f23ed90c5  750A              jnz 0x7f6f23ed90d1
-7f6f23ed90c7  0FB67736          movzx esi, byte [rdi+0x36]
-7f6f23ed90cb  4883FE11          cmp rsi, +0x11
-7f6f23ed90cf  741C              jz 0x7f6f23ed90ed
-7f6f23ed90d1  4881F884000000    cmp rax, 0x84
-7f6f23ed90d8  7413              jz 0x7f6f23ed90ed
-7f6f23ed90da  4883F82C          cmp rax, +0x2c
-7f6f23ed90de  7525              jnz 0x7f6f23ed9105
-7f6f23ed90e0  0FB64736          movzx eax, byte [rdi+0x36]
-7f6f23ed90e4  4881F884000000    cmp rax, 0x84
-7f6f23ed90eb  7518              jnz 0x7f6f23ed9105
-7f6f23ed90ed  0FB74738          movzx eax, word [rdi+0x38]
-7f6f23ed90f1  66C1C808          ror ax, 0x08
-7f6f23ed90f5  480FB7C0          movzx rax, ax
-7f6f23ed90f9  4883F850          cmp rax, +0x50
-7f6f23ed90fd  7C06              jl 0x7f6f23ed9105
-7f6f23ed90ff  4883F85A          cmp rax, +0x5a
-7f6f23ed9103  7E03              jle 0x7f6f23ed9108
-7f6f23ed9105  B000              mov al, 0x0
-7f6f23ed9107  C3                ret
-7f6f23ed9108  B001              mov al, 0x1
-7f6f23ed910a  C3                ret
-
+7f659fa96000  4883FE22          cmp rsi, +0x22
+7f659fa96004  0F8CFB000000      jl 0x7f659fa96105
+7f659fa9600a  0FB7470C          movzx eax, word [rdi+0xc]
+7f659fa9600e  4883F808          cmp rax, +0x08
+7f659fa96012  7576              jnz 0x7f659fa9608a
+7f659fa96014  0FB64F17          movzx ecx, byte [rdi+0x17]
+7f659fa96018  4883F906          cmp rcx, +0x06
+7f659fa9601c  7413              jz 0x7f659fa96031
+7f659fa9601e  4883F911          cmp rcx, +0x11
+7f659fa96022  740D              jz 0x7f659fa96031
+7f659fa96024  4881F984000000    cmp rcx, 0x84
+7f659fa9602b  0F85D4000000      jnz 0x7f659fa96105
+7f659fa96031  0FB74F14          movzx ecx, word [rdi+0x14]
+7f659fa96035  4881E11FFF0000    and rcx, 0xff1f
+7f659fa9603c  4883F900          cmp rcx, +0x00
+7f659fa96040  0F85BF000000      jnz 0x7f659fa96105
+7f659fa96046  0FB64F0E          movzx ecx, byte [rdi+0xe]
+7f659fa9604a  4883E10F          and rcx, +0x0f
+7f659fa9604e  48C1E102          shl rcx, 0x02
+7f659fa96052  89CA              mov edx, ecx
+7f659fa96054  4883C212          add rdx, +0x12
+7f659fa96058  4839F2            cmp rdx, rsi
+7f659fa9605b  0F8FA4000000      jg 0x7f659fa96105
+7f659fa96061  4883C110          add rcx, +0x10
+7f659fa96065  0FB70C0F          movzx ecx, word [rdi+rcx]
+7f659fa96069  66C1C908          ror cx, 0x08
+7f659fa9606d  480FB7C9          movzx rcx, cx
+7f659fa96071  4883F950          cmp rcx, +0x50
+7f659fa96075  0F8C8A000000      jl 0x7f659fa96105
+7f659fa9607b  4883F95A          cmp rcx, +0x5a
+7f659fa9607f  0F8E83000000      jle 0x7f659fa96108
+7f659fa96085  E97B000000        jmp 0x7f659fa96105
+7f659fa9608a  4883FE3A          cmp rsi, +0x3a
+7f659fa9608e  0F8C71000000      jl 0x7f659fa96105
+7f659fa96094  4881F886DD0000    cmp rax, 0xdd86
+7f659fa9609b  0F8564000000      jnz 0x7f659fa96105
+7f659fa960a1  0FB64714          movzx eax, byte [rdi+0x14]
+7f659fa960a5  4883F806          cmp rax, +0x06
+7f659fa960a9  7442              jz 0x7f659fa960ed
+7f659fa960ab  4883F82C          cmp rax, +0x2c
+7f659fa960af  750A              jnz 0x7f659fa960bb
+7f659fa960b1  0FB67736          movzx esi, byte [rdi+0x36]
+7f659fa960b5  4883FE06          cmp rsi, +0x06
+7f659fa960b9  7432              jz 0x7f659fa960ed
+7f659fa960bb  4883F811          cmp rax, +0x11
+7f659fa960bf  742C              jz 0x7f659fa960ed
+7f659fa960c1  4883F82C          cmp rax, +0x2c
+7f659fa960c5  750A              jnz 0x7f659fa960d1
+7f659fa960c7  0FB67736          movzx esi, byte [rdi+0x36]
+7f659fa960cb  4883FE11          cmp rsi, +0x11
+7f659fa960cf  741C              jz 0x7f659fa960ed
+7f659fa960d1  4881F884000000    cmp rax, 0x84
+7f659fa960d8  7413              jz 0x7f659fa960ed
+7f659fa960da  4883F82C          cmp rax, +0x2c
+7f659fa960de  7525              jnz 0x7f659fa96105
+7f659fa960e0  0FB64736          movzx eax, byte [rdi+0x36]
+7f659fa960e4  4881F884000000    cmp rax, 0x84
+7f659fa960eb  7518              jnz 0x7f659fa96105
+7f659fa960ed  0FB74738          movzx eax, word [rdi+0x38]
+7f659fa960f1  66C1C808          ror ax, 0x08
+7f659fa960f5  480FB7C0          movzx rax, ax
+7f659fa960f9  4883F850          cmp rax, +0x50
+7f659fa960fd  7C06              jl 0x7f659fa96105
+7f659fa960ff  4883F85A          cmp rax, +0x5a
+7f659fa96103  7E03              jle 0x7f659fa96108
+7f659fa96105  B000              mov al, 0x0
+7f659fa96107  C3                ret
+7f659fa96108  B001              mov al, 0x1
+7f659fa9610a  C3                ret
 ```
 

--- a/doc/ether-broadcast.md
+++ b/doc/ether-broadcast.md
@@ -41,25 +41,23 @@ return function(P,length)
    if cast("uint16_t*", P+0)[0] ~= 65535 then return false end
    return cast("uint32_t*", P+2)[0] == 4294967295
 end
-
 ```
 
 ## Native pflang compilation
 
 ```
-7fed637de000  4883FE06          cmp rsi, +0x06
-7fed637de004  7C1E              jl 0x7fed637de024
-7fed637de006  0FB737            movzx esi, word [rdi]
-7fed637de009  4881FEFFFF0000    cmp rsi, 0xffff
-7fed637de010  7512              jnz 0x7fed637de024
-7fed637de012  8B7702            mov esi, [rdi+0x2]
-7fed637de015  48B8FFFFFFFF0000. mov rax, 0x00000000ffffffff
-7fed637de01f  4839C6            cmp rsi, rax
-7fed637de022  7403              jz 0x7fed637de027
-7fed637de024  B000              mov al, 0x0
-7fed637de026  C3                ret
-7fed637de027  B001              mov al, 0x1
-7fed637de029  C3                ret
-
+7fe7432af000  4883FE06          cmp rsi, +0x06
+7fe7432af004  7C1E              jl 0x7fe7432af024
+7fe7432af006  0FB737            movzx esi, word [rdi]
+7fe7432af009  4881FEFFFF0000    cmp rsi, 0xffff
+7fe7432af010  7512              jnz 0x7fe7432af024
+7fe7432af012  8B7702            mov esi, [rdi+0x2]
+7fe7432af015  48B8FFFFFFFF0000. mov rax, 0x00000000ffffffff
+7fe7432af01f  4839C6            cmp rsi, rax
+7fe7432af022  7403              jz 0x7fe7432af027
+7fe7432af024  B000              mov al, 0x0
+7fe7432af026  C3                ret
+7fe7432af027  B001              mov al, 0x1
+7fe7432af029  C3                ret
 ```
 

--- a/doc/ether-multicast.md
+++ b/doc/ether-multicast.md
@@ -35,22 +35,20 @@ return function(P,length)
    if length < 1 then return false end
    return band(P[0],1) ~= 0
 end
-
 ```
 
 ## Native pflang compilation
 
 ```
-7f1334222000  4883FE01          cmp rsi, +0x01
-7f1334222004  7C0D              jl 0x7f1334222013
-7f1334222006  0FB637            movzx esi, byte [rdi]
-7f1334222009  4883E601          and rsi, +0x01
-7f133422200d  4883FE00          cmp rsi, +0x00
-7f1334222011  7503              jnz 0x7f1334222016
-7f1334222013  B000              mov al, 0x0
-7f1334222015  C3                ret
-7f1334222016  B001              mov al, 0x1
-7f1334222018  C3                ret
-
+7f0cb1ee1000  4883FE01          cmp rsi, +0x01
+7f0cb1ee1004  7C0D              jl 0x7f0cb1ee1013
+7f0cb1ee1006  0FB637            movzx esi, byte [rdi]
+7f0cb1ee1009  4883E601          and rsi, +0x01
+7f0cb1ee100d  4883FE00          cmp rsi, +0x00
+7f0cb1ee1011  7503              jnz 0x7f0cb1ee1016
+7f0cb1ee1013  B000              mov al, 0x0
+7f0cb1ee1015  C3                ret
+7f0cb1ee1016  B001              mov al, 0x1
+7f0cb1ee1018  C3                ret
 ```
 

--- a/doc/ether-proto-1500.md
+++ b/doc/ether-proto-1500.md
@@ -38,14 +38,12 @@ end
 return function(P,length)
    return false
 end
-
 ```
 
 ## Native pflang compilation
 
 ```
-7f707626d000  B000              mov al, 0x0
-7f707626d002  C3                ret
-
+7f2ba1387000  B000              mov al, 0x0
+7f2ba1387002  C3                ret
 ```
 

--- a/doc/ether-proto-1501.md
+++ b/doc/ether-proto-1501.md
@@ -35,21 +35,19 @@ return function(P,length)
    if length < 14 then return false end
    return cast("uint16_t*", P+12)[0] == 56581
 end
-
 ```
 
 ## Native pflang compilation
 
 ```
-7f5ed57bc000  4883FE0E          cmp rsi, +0x0e
-7f5ed57bc004  7C0D              jl 0x7f5ed57bc013
-7f5ed57bc006  0FB7770C          movzx esi, word [rdi+0xc]
-7f5ed57bc00a  4881FE05DD0000    cmp rsi, 0xdd05
-7f5ed57bc011  7403              jz 0x7f5ed57bc016
-7f5ed57bc013  B000              mov al, 0x0
-7f5ed57bc015  C3                ret
-7f5ed57bc016  B001              mov al, 0x1
-7f5ed57bc018  C3                ret
-
+7f75046ed000  4883FE0E          cmp rsi, +0x0e
+7f75046ed004  7C0D              jl 0x7f75046ed013
+7f75046ed006  0FB7770C          movzx esi, word [rdi+0xc]
+7f75046ed00a  4881FE05DD0000    cmp rsi, 0xdd05
+7f75046ed011  7403              jz 0x7f75046ed016
+7f75046ed013  B000              mov al, 0x0
+7f75046ed015  C3                ret
+7f75046ed016  B001              mov al, 0x1
+7f75046ed018  C3                ret
 ```
 

--- a/doc/ether-proto-255.md
+++ b/doc/ether-proto-255.md
@@ -43,26 +43,24 @@ return function(P,length)
    if rshift(bswap(cast("uint16_t*", P+12)[0]), 16) > 1500 then return false end
    return P[14] == 255
 end
-
 ```
 
 ## Native pflang compilation
 
 ```
-7fed0b2db000  4883FE0F          cmp rsi, +0x0f
-7fed0b2db004  7C22              jl 0x7fed0b2db028
-7fed0b2db006  0FB7770C          movzx esi, word [rdi+0xc]
-7fed0b2db00a  66C1CE08          ror si, 0x08
-7fed0b2db00e  480FB7F6          movzx rsi, si
-7fed0b2db012  4881FEDC050000    cmp rsi, 0x5dc
-7fed0b2db019  7F0D              jg 0x7fed0b2db028
-7fed0b2db01b  0FB6770E          movzx esi, byte [rdi+0xe]
-7fed0b2db01f  4881FEFF000000    cmp rsi, 0xff
-7fed0b2db026  7403              jz 0x7fed0b2db02b
-7fed0b2db028  B000              mov al, 0x0
-7fed0b2db02a  C3                ret
-7fed0b2db02b  B001              mov al, 0x1
-7fed0b2db02d  C3                ret
-
+7f6d220ca000  4883FE0F          cmp rsi, +0x0f
+7f6d220ca004  7C22              jl 0x7f6d220ca028
+7f6d220ca006  0FB7770C          movzx esi, word [rdi+0xc]
+7f6d220ca00a  66C1CE08          ror si, 0x08
+7f6d220ca00e  480FB7F6          movzx rsi, si
+7f6d220ca012  4881FEDC050000    cmp rsi, 0x5dc
+7f6d220ca019  7F0D              jg 0x7f6d220ca028
+7f6d220ca01b  0FB6770E          movzx esi, byte [rdi+0xe]
+7f6d220ca01f  4881FEFF000000    cmp rsi, 0xff
+7f6d220ca026  7403              jz 0x7f6d220ca02b
+7f6d220ca028  B000              mov al, 0x0
+7f6d220ca02a  C3                ret
+7f6d220ca02b  B001              mov al, 0x1
+7f6d220ca02d  C3                ret
 ```
 

--- a/doc/ether-proto-decnet.md
+++ b/doc/ether-proto-decnet.md
@@ -35,21 +35,19 @@ return function(P,length)
    if length < 14 then return false end
    return cast("uint16_t*", P+12)[0] == 864
 end
-
 ```
 
 ## Native pflang compilation
 
 ```
-7f4ca0d63000  4883FE0E          cmp rsi, +0x0e
-7f4ca0d63004  7C0D              jl 0x7f4ca0d63013
-7f4ca0d63006  0FB7770C          movzx esi, word [rdi+0xc]
-7f4ca0d6300a  4881FE60030000    cmp rsi, 0x360
-7f4ca0d63011  7403              jz 0x7f4ca0d63016
-7f4ca0d63013  B000              mov al, 0x0
-7f4ca0d63015  C3                ret
-7f4ca0d63016  B001              mov al, 0x1
-7f4ca0d63018  C3                ret
-
+7f5fb0207000  4883FE0E          cmp rsi, +0x0e
+7f5fb0207004  7C0D              jl 0x7f5fb0207013
+7f5fb0207006  0FB7770C          movzx esi, word [rdi+0xc]
+7f5fb020700a  4881FE60030000    cmp rsi, 0x360
+7f5fb0207011  7403              jz 0x7f5fb0207016
+7f5fb0207013  B000              mov al, 0x0
+7f5fb0207015  C3                ret
+7f5fb0207016  B001              mov al, 0x1
+7f5fb0207018  C3                ret
 ```
 

--- a/doc/fail-fail.md
+++ b/doc/fail-fail.md
@@ -65,39 +65,37 @@ return function(P,length)
    if (v1 + 115) > length then return false end
    return P[(v1 + 114)] == 1
 end
-
 ```
 
 ## Native pflang compilation
 
 ```
-7f6695339000  4883FE36          cmp rsi, +0x36
-7f6695339004  7C4A              jl 0x7f6695339050
-7f6695339006  0FB7470C          movzx eax, word [rdi+0xc]
-7f669533900a  4883F808          cmp rax, +0x08
-7f669533900e  7540              jnz 0x7f6695339050
-7f6695339010  0FB64717          movzx eax, byte [rdi+0x17]
-7f6695339014  4883F806          cmp rax, +0x06
-7f6695339018  7536              jnz 0x7f6695339050
-7f669533901a  0FB74714          movzx eax, word [rdi+0x14]
-7f669533901e  4881E01FFF0000    and rax, 0xff1f
-7f6695339025  4883F800          cmp rax, +0x00
-7f6695339029  7525              jnz 0x7f6695339050
-7f669533902b  0FB6470E          movzx eax, byte [rdi+0xe]
-7f669533902f  4883E00F          and rax, +0x0f
-7f6695339033  48C1E002          shl rax, 0x02
-7f6695339037  89C1              mov ecx, eax
-7f6695339039  4883C173          add rcx, +0x73
-7f669533903d  4839F1            cmp rcx, rsi
-7f6695339040  7F0E              jg 0x7f6695339050
-7f6695339042  4883C072          add rax, +0x72
-7f6695339046  0FB60407          movzx eax, byte [rdi+rax]
-7f669533904a  4883F801          cmp rax, +0x01
-7f669533904e  7403              jz 0x7f6695339053
-7f6695339050  B000              mov al, 0x0
-7f6695339052  C3                ret
-7f6695339053  B001              mov al, 0x1
-7f6695339055  C3                ret
-
+7f53634ae000  4883FE36          cmp rsi, +0x36
+7f53634ae004  7C4A              jl 0x7f53634ae050
+7f53634ae006  0FB7470C          movzx eax, word [rdi+0xc]
+7f53634ae00a  4883F808          cmp rax, +0x08
+7f53634ae00e  7540              jnz 0x7f53634ae050
+7f53634ae010  0FB64717          movzx eax, byte [rdi+0x17]
+7f53634ae014  4883F806          cmp rax, +0x06
+7f53634ae018  7536              jnz 0x7f53634ae050
+7f53634ae01a  0FB74714          movzx eax, word [rdi+0x14]
+7f53634ae01e  4881E01FFF0000    and rax, 0xff1f
+7f53634ae025  4883F800          cmp rax, +0x00
+7f53634ae029  7525              jnz 0x7f53634ae050
+7f53634ae02b  0FB6470E          movzx eax, byte [rdi+0xe]
+7f53634ae02f  4883E00F          and rax, +0x0f
+7f53634ae033  48C1E002          shl rax, 0x02
+7f53634ae037  89C1              mov ecx, eax
+7f53634ae039  4883C173          add rcx, +0x73
+7f53634ae03d  4839F1            cmp rcx, rsi
+7f53634ae040  7F0E              jg 0x7f53634ae050
+7f53634ae042  4883C072          add rax, +0x72
+7f53634ae046  0FB60407          movzx eax, byte [rdi+rax]
+7f53634ae04a  4883F801          cmp rax, +0x01
+7f53634ae04e  7403              jz 0x7f53634ae053
+7f53634ae050  B000              mov al, 0x0
+7f53634ae052  C3                ret
+7f53634ae053  B001              mov al, 0x1
+7f53634ae055  C3                ret
 ```
 

--- a/doc/host-127.0.0.1.md
+++ b/doc/host-127.0.0.1.md
@@ -77,40 +77,38 @@ return function(P,length)
       return cast("uint32_t*", P+38)[0] == 16777343
    end
 end
-
 ```
 
 ## Native pflang compilation
 
 ```
-7f78e093a000  4883FE22          cmp rsi, +0x22
-7f78e093a004  7C54              jl 0x7f78e093a05a
-7f78e093a006  0FB7470C          movzx eax, word [rdi+0xc]
-7f78e093a00a  4883F808          cmp rax, +0x08
-7f78e093a00e  751A              jnz 0x7f78e093a02a
-7f78e093a010  8B4F1A            mov ecx, [rdi+0x1a]
-7f78e093a013  4881F97F000001    cmp rcx, 0x0100007f
-7f78e093a01a  7441              jz 0x7f78e093a05d
-7f78e093a01c  8B4F1E            mov ecx, [rdi+0x1e]
-7f78e093a01f  4881F97F000001    cmp rcx, 0x0100007f
-7f78e093a026  7435              jz 0x7f78e093a05d
-7f78e093a028  EB30              jmp 0x7f78e093a05a
-7f78e093a02a  4883FE2A          cmp rsi, +0x2a
-7f78e093a02e  7C2A              jl 0x7f78e093a05a
-7f78e093a030  4881F808060000    cmp rax, 0x608
-7f78e093a037  7409              jz 0x7f78e093a042
-7f78e093a039  4881F880350000    cmp rax, 0x3580
-7f78e093a040  7518              jnz 0x7f78e093a05a
-7f78e093a042  8B471C            mov eax, [rdi+0x1c]
-7f78e093a045  4881F87F000001    cmp rax, 0x0100007f
-7f78e093a04c  740F              jz 0x7f78e093a05d
-7f78e093a04e  8B4726            mov eax, [rdi+0x26]
-7f78e093a051  4881F87F000001    cmp rax, 0x0100007f
-7f78e093a058  7403              jz 0x7f78e093a05d
-7f78e093a05a  B000              mov al, 0x0
-7f78e093a05c  C3                ret
-7f78e093a05d  B001              mov al, 0x1
-7f78e093a05f  C3                ret
-
+7fb06b836000  4883FE22          cmp rsi, +0x22
+7fb06b836004  7C54              jl 0x7fb06b83605a
+7fb06b836006  0FB7470C          movzx eax, word [rdi+0xc]
+7fb06b83600a  4883F808          cmp rax, +0x08
+7fb06b83600e  751A              jnz 0x7fb06b83602a
+7fb06b836010  8B4F1A            mov ecx, [rdi+0x1a]
+7fb06b836013  4881F97F000001    cmp rcx, 0x0100007f
+7fb06b83601a  7441              jz 0x7fb06b83605d
+7fb06b83601c  8B4F1E            mov ecx, [rdi+0x1e]
+7fb06b83601f  4881F97F000001    cmp rcx, 0x0100007f
+7fb06b836026  7435              jz 0x7fb06b83605d
+7fb06b836028  EB30              jmp 0x7fb06b83605a
+7fb06b83602a  4883FE2A          cmp rsi, +0x2a
+7fb06b83602e  7C2A              jl 0x7fb06b83605a
+7fb06b836030  4881F808060000    cmp rax, 0x608
+7fb06b836037  7409              jz 0x7fb06b836042
+7fb06b836039  4881F880350000    cmp rax, 0x3580
+7fb06b836040  7518              jnz 0x7fb06b83605a
+7fb06b836042  8B471C            mov eax, [rdi+0x1c]
+7fb06b836045  4881F87F000001    cmp rax, 0x0100007f
+7fb06b83604c  740F              jz 0x7fb06b83605d
+7fb06b83604e  8B4726            mov eax, [rdi+0x26]
+7fb06b836051  4881F87F000001    cmp rax, 0x0100007f
+7fb06b836058  7403              jz 0x7fb06b83605d
+7fb06b83605a  B000              mov al, 0x0
+7fb06b83605c  C3                ret
+7fb06b83605d  B001              mov al, 0x1
+7fb06b83605f  C3                ret
 ```
 

--- a/doc/host-ipv6-localhost.md
+++ b/doc/host-ipv6-localhost.md
@@ -89,45 +89,43 @@ return function(P,length)
    if cast("uint32_t*", P+46)[0] ~= 0 then return false end
    return cast("uint32_t*", P+50)[0] == 16777216
 end
-
 ```
 
 ## Native pflang compilation
 
 ```
-7f3176ecb000  4883FE36          cmp rsi, +0x36
-7f3176ecb004  7C5B              jl 0x7f3176ecb061
-7f3176ecb006  0FB7770C          movzx esi, word [rdi+0xc]
-7f3176ecb00a  4881FE86DD0000    cmp rsi, 0xdd86
-7f3176ecb011  754E              jnz 0x7f3176ecb061
-7f3176ecb013  8B7716            mov esi, [rdi+0x16]
-7f3176ecb016  4883FE00          cmp rsi, +0x00
-7f3176ecb01a  751E              jnz 0x7f3176ecb03a
-7f3176ecb01c  8B771A            mov esi, [rdi+0x1a]
-7f3176ecb01f  4883FE00          cmp rsi, +0x00
-7f3176ecb023  7515              jnz 0x7f3176ecb03a
-7f3176ecb025  8B771E            mov esi, [rdi+0x1e]
-7f3176ecb028  4883FE00          cmp rsi, +0x00
-7f3176ecb02c  750C              jnz 0x7f3176ecb03a
-7f3176ecb02e  8B7722            mov esi, [rdi+0x22]
-7f3176ecb031  4881FE00000001    cmp rsi, 0x01000000
-7f3176ecb038  742A              jz 0x7f3176ecb064
-7f3176ecb03a  8B7726            mov esi, [rdi+0x26]
-7f3176ecb03d  4883FE00          cmp rsi, +0x00
-7f3176ecb041  751E              jnz 0x7f3176ecb061
-7f3176ecb043  8B772A            mov esi, [rdi+0x2a]
-7f3176ecb046  4883FE00          cmp rsi, +0x00
-7f3176ecb04a  7515              jnz 0x7f3176ecb061
-7f3176ecb04c  8B772E            mov esi, [rdi+0x2e]
-7f3176ecb04f  4883FE00          cmp rsi, +0x00
-7f3176ecb053  750C              jnz 0x7f3176ecb061
-7f3176ecb055  8B7732            mov esi, [rdi+0x32]
-7f3176ecb058  4881FE00000001    cmp rsi, 0x01000000
-7f3176ecb05f  7403              jz 0x7f3176ecb064
-7f3176ecb061  B000              mov al, 0x0
-7f3176ecb063  C3                ret
-7f3176ecb064  B001              mov al, 0x1
-7f3176ecb066  C3                ret
-
+7f5e7dc55000  4883FE36          cmp rsi, +0x36
+7f5e7dc55004  7C5B              jl 0x7f5e7dc55061
+7f5e7dc55006  0FB7770C          movzx esi, word [rdi+0xc]
+7f5e7dc5500a  4881FE86DD0000    cmp rsi, 0xdd86
+7f5e7dc55011  754E              jnz 0x7f5e7dc55061
+7f5e7dc55013  8B7716            mov esi, [rdi+0x16]
+7f5e7dc55016  4883FE00          cmp rsi, +0x00
+7f5e7dc5501a  751E              jnz 0x7f5e7dc5503a
+7f5e7dc5501c  8B771A            mov esi, [rdi+0x1a]
+7f5e7dc5501f  4883FE00          cmp rsi, +0x00
+7f5e7dc55023  7515              jnz 0x7f5e7dc5503a
+7f5e7dc55025  8B771E            mov esi, [rdi+0x1e]
+7f5e7dc55028  4883FE00          cmp rsi, +0x00
+7f5e7dc5502c  750C              jnz 0x7f5e7dc5503a
+7f5e7dc5502e  8B7722            mov esi, [rdi+0x22]
+7f5e7dc55031  4881FE00000001    cmp rsi, 0x01000000
+7f5e7dc55038  742A              jz 0x7f5e7dc55064
+7f5e7dc5503a  8B7726            mov esi, [rdi+0x26]
+7f5e7dc5503d  4883FE00          cmp rsi, +0x00
+7f5e7dc55041  751E              jnz 0x7f5e7dc55061
+7f5e7dc55043  8B772A            mov esi, [rdi+0x2a]
+7f5e7dc55046  4883FE00          cmp rsi, +0x00
+7f5e7dc5504a  7515              jnz 0x7f5e7dc55061
+7f5e7dc5504c  8B772E            mov esi, [rdi+0x2e]
+7f5e7dc5504f  4883FE00          cmp rsi, +0x00
+7f5e7dc55053  750C              jnz 0x7f5e7dc55061
+7f5e7dc55055  8B7732            mov esi, [rdi+0x32]
+7f5e7dc55058  4881FE00000001    cmp rsi, 0x01000000
+7f5e7dc5505f  7403              jz 0x7f5e7dc55064
+7f5e7dc55061  B000              mov al, 0x0
+7f5e7dc55063  C3                ret
+7f5e7dc55064  B001              mov al, 0x1
+7f5e7dc55066  C3                ret
 ```
 

--- a/doc/icmp-or-tcp-or-udp.md
+++ b/doc/icmp-or-tcp-or-udp.md
@@ -92,61 +92,59 @@ return function(P,length)
       return P[54] == 17
    end
 end
-
 ```
 
 ## Native pflang compilation
 
 ```
-7f2faa4a1000  4883FE22          cmp rsi, +0x22
-7f2faa4a1004  0F8CA0000000      jl 0x7f2faa4a10aa
-7f2faa4a100a  0FB7470C          movzx eax, word [rdi+0xc]
-7f2faa4a100e  4883F808          cmp rax, +0x08
-7f2faa4a1012  7527              jnz 0x7f2faa4a103b
-7f2faa4a1014  0FB64F17          movzx ecx, byte [rdi+0x17]
-7f2faa4a1018  4883F901          cmp rcx, +0x01
-7f2faa4a101c  0F848B000000      jz 0x7f2faa4a10ad
-7f2faa4a1022  4883F906          cmp rcx, +0x06
-7f2faa4a1026  0F8481000000      jz 0x7f2faa4a10ad
-7f2faa4a102c  4883F911          cmp rcx, +0x11
-7f2faa4a1030  0F8477000000      jz 0x7f2faa4a10ad
-7f2faa4a1036  E96F000000        jmp 0x7f2faa4a10aa
-7f2faa4a103b  4883FE36          cmp rsi, +0x36
-7f2faa4a103f  0F8C65000000      jl 0x7f2faa4a10aa
-7f2faa4a1045  4881F886DD0000    cmp rax, 0xdd86
-7f2faa4a104c  0F8558000000      jnz 0x7f2faa4a10aa
-7f2faa4a1052  0FB64714          movzx eax, byte [rdi+0x14]
-7f2faa4a1056  4883F801          cmp rax, +0x01
-7f2faa4a105a  7451              jz 0x7f2faa4a10ad
-7f2faa4a105c  4883FE37          cmp rsi, +0x37
-7f2faa4a1060  7C10              jl 0x7f2faa4a1072
-7f2faa4a1062  4883F82C          cmp rax, +0x2c
-7f2faa4a1066  750A              jnz 0x7f2faa4a1072
-7f2faa4a1068  0FB64F36          movzx ecx, byte [rdi+0x36]
-7f2faa4a106c  4883F901          cmp rcx, +0x01
-7f2faa4a1070  743B              jz 0x7f2faa4a10ad
-7f2faa4a1072  4883F806          cmp rax, +0x06
-7f2faa4a1076  7435              jz 0x7f2faa4a10ad
-7f2faa4a1078  4883FE37          cmp rsi, +0x37
-7f2faa4a107c  7C10              jl 0x7f2faa4a108e
-7f2faa4a107e  4883F82C          cmp rax, +0x2c
-7f2faa4a1082  750A              jnz 0x7f2faa4a108e
-7f2faa4a1084  0FB64F36          movzx ecx, byte [rdi+0x36]
-7f2faa4a1088  4883F906          cmp rcx, +0x06
-7f2faa4a108c  741F              jz 0x7f2faa4a10ad
-7f2faa4a108e  4883F811          cmp rax, +0x11
-7f2faa4a1092  7419              jz 0x7f2faa4a10ad
-7f2faa4a1094  4883FE37          cmp rsi, +0x37
-7f2faa4a1098  7C10              jl 0x7f2faa4a10aa
-7f2faa4a109a  4883F82C          cmp rax, +0x2c
-7f2faa4a109e  750A              jnz 0x7f2faa4a10aa
-7f2faa4a10a0  0FB64736          movzx eax, byte [rdi+0x36]
-7f2faa4a10a4  4883F811          cmp rax, +0x11
-7f2faa4a10a8  7403              jz 0x7f2faa4a10ad
-7f2faa4a10aa  B000              mov al, 0x0
-7f2faa4a10ac  C3                ret
-7f2faa4a10ad  B001              mov al, 0x1
-7f2faa4a10af  C3                ret
-
+7f4da024f000  4883FE22          cmp rsi, +0x22
+7f4da024f004  0F8CA0000000      jl 0x7f4da024f0aa
+7f4da024f00a  0FB7470C          movzx eax, word [rdi+0xc]
+7f4da024f00e  4883F808          cmp rax, +0x08
+7f4da024f012  7527              jnz 0x7f4da024f03b
+7f4da024f014  0FB64F17          movzx ecx, byte [rdi+0x17]
+7f4da024f018  4883F901          cmp rcx, +0x01
+7f4da024f01c  0F848B000000      jz 0x7f4da024f0ad
+7f4da024f022  4883F906          cmp rcx, +0x06
+7f4da024f026  0F8481000000      jz 0x7f4da024f0ad
+7f4da024f02c  4883F911          cmp rcx, +0x11
+7f4da024f030  0F8477000000      jz 0x7f4da024f0ad
+7f4da024f036  E96F000000        jmp 0x7f4da024f0aa
+7f4da024f03b  4883FE36          cmp rsi, +0x36
+7f4da024f03f  0F8C65000000      jl 0x7f4da024f0aa
+7f4da024f045  4881F886DD0000    cmp rax, 0xdd86
+7f4da024f04c  0F8558000000      jnz 0x7f4da024f0aa
+7f4da024f052  0FB64714          movzx eax, byte [rdi+0x14]
+7f4da024f056  4883F801          cmp rax, +0x01
+7f4da024f05a  7451              jz 0x7f4da024f0ad
+7f4da024f05c  4883FE37          cmp rsi, +0x37
+7f4da024f060  7C10              jl 0x7f4da024f072
+7f4da024f062  4883F82C          cmp rax, +0x2c
+7f4da024f066  750A              jnz 0x7f4da024f072
+7f4da024f068  0FB64F36          movzx ecx, byte [rdi+0x36]
+7f4da024f06c  4883F901          cmp rcx, +0x01
+7f4da024f070  743B              jz 0x7f4da024f0ad
+7f4da024f072  4883F806          cmp rax, +0x06
+7f4da024f076  7435              jz 0x7f4da024f0ad
+7f4da024f078  4883FE37          cmp rsi, +0x37
+7f4da024f07c  7C10              jl 0x7f4da024f08e
+7f4da024f07e  4883F82C          cmp rax, +0x2c
+7f4da024f082  750A              jnz 0x7f4da024f08e
+7f4da024f084  0FB64F36          movzx ecx, byte [rdi+0x36]
+7f4da024f088  4883F906          cmp rcx, +0x06
+7f4da024f08c  741F              jz 0x7f4da024f0ad
+7f4da024f08e  4883F811          cmp rax, +0x11
+7f4da024f092  7419              jz 0x7f4da024f0ad
+7f4da024f094  4883FE37          cmp rsi, +0x37
+7f4da024f098  7C10              jl 0x7f4da024f0aa
+7f4da024f09a  4883F82C          cmp rax, +0x2c
+7f4da024f09e  750A              jnz 0x7f4da024f0aa
+7f4da024f0a0  0FB64736          movzx eax, byte [rdi+0x36]
+7f4da024f0a4  4883F811          cmp rax, +0x11
+7f4da024f0a8  7403              jz 0x7f4da024f0ad
+7f4da024f0aa  B000              mov al, 0x0
+7f4da024f0ac  C3                ret
+7f4da024f0ad  B001              mov al, 0x1
+7f4da024f0af  C3                ret
 ```
 

--- a/doc/icmp6-or-ip.md
+++ b/doc/icmp6-or-ip.md
@@ -63,36 +63,34 @@ return function(P,length)
 ::L7::
    return cast("uint16_t*", P+12)[0] == 8
 end
-
 ```
 
 ## Native pflang compilation
 
 ```
-7f97ad46a000  4883FE0E          cmp rsi, +0x0e
-7f97ad46a004  7C3D              jl 0x7f97ad46a043
-7f97ad46a006  4883FE36          cmp rsi, +0x36
-7f97ad46a00a  7C2D              jl 0x7f97ad46a039
-7f97ad46a00c  0FB7470C          movzx eax, word [rdi+0xc]
-7f97ad46a010  4881F886DD0000    cmp rax, 0xdd86
-7f97ad46a017  7520              jnz 0x7f97ad46a039
-7f97ad46a019  0FB64714          movzx eax, byte [rdi+0x14]
-7f97ad46a01d  4883F83A          cmp rax, +0x3a
-7f97ad46a021  7423              jz 0x7f97ad46a046
-7f97ad46a023  4883FE37          cmp rsi, +0x37
-7f97ad46a027  7C10              jl 0x7f97ad46a039
-7f97ad46a029  4883F82C          cmp rax, +0x2c
-7f97ad46a02d  750A              jnz 0x7f97ad46a039
-7f97ad46a02f  0FB64736          movzx eax, byte [rdi+0x36]
-7f97ad46a033  4883F83A          cmp rax, +0x3a
-7f97ad46a037  740D              jz 0x7f97ad46a046
-7f97ad46a039  0FB7470C          movzx eax, word [rdi+0xc]
-7f97ad46a03d  4883F808          cmp rax, +0x08
-7f97ad46a041  7403              jz 0x7f97ad46a046
-7f97ad46a043  B000              mov al, 0x0
-7f97ad46a045  C3                ret
-7f97ad46a046  B001              mov al, 0x1
-7f97ad46a048  C3                ret
-
+7f1c0b4a5000  4883FE0E          cmp rsi, +0x0e
+7f1c0b4a5004  7C3D              jl 0x7f1c0b4a5043
+7f1c0b4a5006  4883FE36          cmp rsi, +0x36
+7f1c0b4a500a  7C2D              jl 0x7f1c0b4a5039
+7f1c0b4a500c  0FB7470C          movzx eax, word [rdi+0xc]
+7f1c0b4a5010  4881F886DD0000    cmp rax, 0xdd86
+7f1c0b4a5017  7520              jnz 0x7f1c0b4a5039
+7f1c0b4a5019  0FB64714          movzx eax, byte [rdi+0x14]
+7f1c0b4a501d  4883F83A          cmp rax, +0x3a
+7f1c0b4a5021  7423              jz 0x7f1c0b4a5046
+7f1c0b4a5023  4883FE37          cmp rsi, +0x37
+7f1c0b4a5027  7C10              jl 0x7f1c0b4a5039
+7f1c0b4a5029  4883F82C          cmp rax, +0x2c
+7f1c0b4a502d  750A              jnz 0x7f1c0b4a5039
+7f1c0b4a502f  0FB64736          movzx eax, byte [rdi+0x36]
+7f1c0b4a5033  4883F83A          cmp rax, +0x3a
+7f1c0b4a5037  740D              jz 0x7f1c0b4a5046
+7f1c0b4a5039  0FB7470C          movzx eax, word [rdi+0xc]
+7f1c0b4a503d  4883F808          cmp rax, +0x08
+7f1c0b4a5041  7403              jz 0x7f1c0b4a5046
+7f1c0b4a5043  B000              mov al, 0x0
+7f1c0b4a5045  C3                ret
+7f1c0b4a5046  B001              mov al, 0x1
+7f1c0b4a5048  C3                ret
 ```
 

--- a/doc/icmp6.md
+++ b/doc/icmp6.md
@@ -53,31 +53,29 @@ return function(P,length)
    if v1 ~= 44 then return false end
    return P[54] == 58
 end
-
 ```
 
 ## Native pflang compilation
 
 ```
-7f714d5b9000  4883FE36          cmp rsi, +0x36
-7f714d5b9004  7C2D              jl 0x7f714d5b9033
-7f714d5b9006  0FB7470C          movzx eax, word [rdi+0xc]
-7f714d5b900a  4881F886DD0000    cmp rax, 0xdd86
-7f714d5b9011  7520              jnz 0x7f714d5b9033
-7f714d5b9013  0FB64714          movzx eax, byte [rdi+0x14]
-7f714d5b9017  4883F83A          cmp rax, +0x3a
-7f714d5b901b  7419              jz 0x7f714d5b9036
-7f714d5b901d  4883FE37          cmp rsi, +0x37
-7f714d5b9021  7C10              jl 0x7f714d5b9033
-7f714d5b9023  4883F82C          cmp rax, +0x2c
-7f714d5b9027  750A              jnz 0x7f714d5b9033
-7f714d5b9029  0FB64736          movzx eax, byte [rdi+0x36]
-7f714d5b902d  4883F83A          cmp rax, +0x3a
-7f714d5b9031  7403              jz 0x7f714d5b9036
-7f714d5b9033  B000              mov al, 0x0
-7f714d5b9035  C3                ret
-7f714d5b9036  B001              mov al, 0x1
-7f714d5b9038  C3                ret
-
+7f126be87000  4883FE36          cmp rsi, +0x36
+7f126be87004  7C2D              jl 0x7f126be87033
+7f126be87006  0FB7470C          movzx eax, word [rdi+0xc]
+7f126be8700a  4881F886DD0000    cmp rax, 0xdd86
+7f126be87011  7520              jnz 0x7f126be87033
+7f126be87013  0FB64714          movzx eax, byte [rdi+0x14]
+7f126be87017  4883F83A          cmp rax, +0x3a
+7f126be8701b  7419              jz 0x7f126be87036
+7f126be8701d  4883FE37          cmp rsi, +0x37
+7f126be87021  7C10              jl 0x7f126be87033
+7f126be87023  4883F82C          cmp rax, +0x2c
+7f126be87027  750A              jnz 0x7f126be87033
+7f126be87029  0FB64736          movzx eax, byte [rdi+0x36]
+7f126be8702d  4883F83A          cmp rax, +0x3a
+7f126be87031  7403              jz 0x7f126be87036
+7f126be87033  B000              mov al, 0x0
+7f126be87035  C3                ret
+7f126be87036  B001              mov al, 0x1
+7f126be87038  C3                ret
 ```
 

--- a/doc/ip-multicast.md
+++ b/doc/ip-multicast.md
@@ -41,24 +41,22 @@ return function(P,length)
    if cast("uint16_t*", P+12)[0] ~= 8 then return false end
    return P[30] == 224
 end
-
 ```
 
 ## Native pflang compilation
 
 ```
-7f162eceb000  4883FE22          cmp rsi, +0x22
-7f162eceb004  7C17              jl 0x7f162eceb01d
-7f162eceb006  0FB7770C          movzx esi, word [rdi+0xc]
-7f162eceb00a  4883FE08          cmp rsi, +0x08
-7f162eceb00e  750D              jnz 0x7f162eceb01d
-7f162eceb010  0FB6771E          movzx esi, byte [rdi+0x1e]
-7f162eceb014  4881FEE0000000    cmp rsi, 0xe0
-7f162eceb01b  7403              jz 0x7f162eceb020
-7f162eceb01d  B000              mov al, 0x0
-7f162eceb01f  C3                ret
-7f162eceb020  B001              mov al, 0x1
-7f162eceb022  C3                ret
-
+7f7e5045a000  4883FE22          cmp rsi, +0x22
+7f7e5045a004  7C17              jl 0x7f7e5045a01d
+7f7e5045a006  0FB7770C          movzx esi, word [rdi+0xc]
+7f7e5045a00a  4883FE08          cmp rsi, +0x08
+7f7e5045a00e  750D              jnz 0x7f7e5045a01d
+7f7e5045a010  0FB6771E          movzx esi, byte [rdi+0x1e]
+7f7e5045a014  4881FEE0000000    cmp rsi, 0xe0
+7f7e5045a01b  7403              jz 0x7f7e5045a020
+7f7e5045a01d  B000              mov al, 0x0
+7f7e5045a01f  C3                ret
+7f7e5045a020  B001              mov al, 0x1
+7f7e5045a022  C3                ret
 ```
 

--- a/doc/ip-proto-47.md
+++ b/doc/ip-proto-47.md
@@ -41,24 +41,22 @@ return function(P,length)
    if cast("uint16_t*", P+12)[0] ~= 8 then return false end
    return P[23] == 47
 end
-
 ```
 
 ## Native pflang compilation
 
 ```
-7f9474820000  4883FE22          cmp rsi, +0x22
-7f9474820004  7C14              jl 0x7f947482001a
-7f9474820006  0FB7770C          movzx esi, word [rdi+0xc]
-7f947482000a  4883FE08          cmp rsi, +0x08
-7f947482000e  750A              jnz 0x7f947482001a
-7f9474820010  0FB67717          movzx esi, byte [rdi+0x17]
-7f9474820014  4883FE2F          cmp rsi, +0x2f
-7f9474820018  7403              jz 0x7f947482001d
-7f947482001a  B000              mov al, 0x0
-7f947482001c  C3                ret
-7f947482001d  B001              mov al, 0x1
-7f947482001f  C3                ret
-
+7f2466113000  4883FE22          cmp rsi, +0x22
+7f2466113004  7C14              jl 0x7f246611301a
+7f2466113006  0FB7770C          movzx esi, word [rdi+0xc]
+7f246611300a  4883FE08          cmp rsi, +0x08
+7f246611300e  750A              jnz 0x7f246611301a
+7f2466113010  0FB67717          movzx esi, byte [rdi+0x17]
+7f2466113014  4883FE2F          cmp rsi, +0x2f
+7f2466113018  7403              jz 0x7f246611301d
+7f246611301a  B000              mov al, 0x0
+7f246611301c  C3                ret
+7f246611301d  B001              mov al, 0x1
+7f246611301f  C3                ret
 ```
 

--- a/doc/ip-proto-ah.md
+++ b/doc/ip-proto-ah.md
@@ -41,24 +41,22 @@ return function(P,length)
    if cast("uint16_t*", P+12)[0] ~= 8 then return false end
    return P[23] == 51
 end
-
 ```
 
 ## Native pflang compilation
 
 ```
-7faeba715000  4883FE22          cmp rsi, +0x22
-7faeba715004  7C14              jl 0x7faeba71501a
-7faeba715006  0FB7770C          movzx esi, word [rdi+0xc]
-7faeba71500a  4883FE08          cmp rsi, +0x08
-7faeba71500e  750A              jnz 0x7faeba71501a
-7faeba715010  0FB67717          movzx esi, byte [rdi+0x17]
-7faeba715014  4883FE33          cmp rsi, +0x33
-7faeba715018  7403              jz 0x7faeba71501d
-7faeba71501a  B000              mov al, 0x0
-7faeba71501c  C3                ret
-7faeba71501d  B001              mov al, 0x1
-7faeba71501f  C3                ret
-
+7f58f3365000  4883FE22          cmp rsi, +0x22
+7f58f3365004  7C14              jl 0x7f58f336501a
+7f58f3365006  0FB7770C          movzx esi, word [rdi+0xc]
+7f58f336500a  4883FE08          cmp rsi, +0x08
+7f58f336500e  750A              jnz 0x7f58f336501a
+7f58f3365010  0FB67717          movzx esi, byte [rdi+0x17]
+7f58f3365014  4883FE33          cmp rsi, +0x33
+7f58f3365018  7403              jz 0x7f58f336501d
+7f58f336501a  B000              mov al, 0x0
+7f58f336501c  C3                ret
+7f58f336501d  B001              mov al, 0x1
+7f58f336501f  C3                ret
 ```
 

--- a/doc/ip-proto-sctp.md
+++ b/doc/ip-proto-sctp.md
@@ -41,24 +41,22 @@ return function(P,length)
    if cast("uint16_t*", P+12)[0] ~= 8 then return false end
    return P[23] == 132
 end
-
 ```
 
 ## Native pflang compilation
 
 ```
-7fea96759000  4883FE22          cmp rsi, +0x22
-7fea96759004  7C17              jl 0x7fea9675901d
-7fea96759006  0FB7770C          movzx esi, word [rdi+0xc]
-7fea9675900a  4883FE08          cmp rsi, +0x08
-7fea9675900e  750D              jnz 0x7fea9675901d
-7fea96759010  0FB67717          movzx esi, byte [rdi+0x17]
-7fea96759014  4881FE84000000    cmp rsi, 0x84
-7fea9675901b  7403              jz 0x7fea96759020
-7fea9675901d  B000              mov al, 0x0
-7fea9675901f  C3                ret
-7fea96759020  B001              mov al, 0x1
-7fea96759022  C3                ret
-
+7f91933dd000  4883FE22          cmp rsi, +0x22
+7f91933dd004  7C17              jl 0x7f91933dd01d
+7f91933dd006  0FB7770C          movzx esi, word [rdi+0xc]
+7f91933dd00a  4883FE08          cmp rsi, +0x08
+7f91933dd00e  750D              jnz 0x7f91933dd01d
+7f91933dd010  0FB67717          movzx esi, byte [rdi+0x17]
+7f91933dd014  4881FE84000000    cmp rsi, 0x84
+7f91933dd01b  7403              jz 0x7f91933dd020
+7f91933dd01d  B000              mov al, 0x0
+7f91933dd01f  C3                ret
+7f91933dd020  B001              mov al, 0x1
+7f91933dd022  C3                ret
 ```
 

--- a/doc/ip6-multicast.md
+++ b/doc/ip6-multicast.md
@@ -41,24 +41,22 @@ return function(P,length)
    if cast("uint16_t*", P+12)[0] ~= 56710 then return false end
    return P[38] == 255
 end
-
 ```
 
 ## Native pflang compilation
 
 ```
-7f9db26f0000  4883FE36          cmp rsi, +0x36
-7f9db26f0004  7C1A              jl 0x7f9db26f0020
-7f9db26f0006  0FB7770C          movzx esi, word [rdi+0xc]
-7f9db26f000a  4881FE86DD0000    cmp rsi, 0xdd86
-7f9db26f0011  750D              jnz 0x7f9db26f0020
-7f9db26f0013  0FB67726          movzx esi, byte [rdi+0x26]
-7f9db26f0017  4881FEFF000000    cmp rsi, 0xff
-7f9db26f001e  7403              jz 0x7f9db26f0023
-7f9db26f0020  B000              mov al, 0x0
-7f9db26f0022  C3                ret
-7f9db26f0023  B001              mov al, 0x1
-7f9db26f0025  C3                ret
-
+7f0b5442c000  4883FE36          cmp rsi, +0x36
+7f0b5442c004  7C1A              jl 0x7f0b5442c020
+7f0b5442c006  0FB7770C          movzx esi, word [rdi+0xc]
+7f0b5442c00a  4881FE86DD0000    cmp rsi, 0xdd86
+7f0b5442c011  750D              jnz 0x7f0b5442c020
+7f0b5442c013  0FB67726          movzx esi, byte [rdi+0x26]
+7f0b5442c017  4881FEFF000000    cmp rsi, 0xff
+7f0b5442c01e  7403              jz 0x7f0b5442c023
+7f0b5442c020  B000              mov al, 0x0
+7f0b5442c022  C3                ret
+7f0b5442c023  B001              mov al, 0x1
+7f0b5442c025  C3                ret
 ```
 

--- a/doc/ip6-proto-47.md
+++ b/doc/ip6-proto-47.md
@@ -53,31 +53,29 @@ return function(P,length)
    if v1 ~= 44 then return false end
    return P[54] == 47
 end
-
 ```
 
 ## Native pflang compilation
 
 ```
-7fe19f54c000  4883FE36          cmp rsi, +0x36
-7fe19f54c004  7C2D              jl 0x7fe19f54c033
-7fe19f54c006  0FB7470C          movzx eax, word [rdi+0xc]
-7fe19f54c00a  4881F886DD0000    cmp rax, 0xdd86
-7fe19f54c011  7520              jnz 0x7fe19f54c033
-7fe19f54c013  0FB64714          movzx eax, byte [rdi+0x14]
-7fe19f54c017  4883F82F          cmp rax, +0x2f
-7fe19f54c01b  7419              jz 0x7fe19f54c036
-7fe19f54c01d  4883FE37          cmp rsi, +0x37
-7fe19f54c021  7C10              jl 0x7fe19f54c033
-7fe19f54c023  4883F82C          cmp rax, +0x2c
-7fe19f54c027  750A              jnz 0x7fe19f54c033
-7fe19f54c029  0FB64736          movzx eax, byte [rdi+0x36]
-7fe19f54c02d  4883F82F          cmp rax, +0x2f
-7fe19f54c031  7403              jz 0x7fe19f54c036
-7fe19f54c033  B000              mov al, 0x0
-7fe19f54c035  C3                ret
-7fe19f54c036  B001              mov al, 0x1
-7fe19f54c038  C3                ret
-
+7fa374c2d000  4883FE36          cmp rsi, +0x36
+7fa374c2d004  7C2D              jl 0x7fa374c2d033
+7fa374c2d006  0FB7470C          movzx eax, word [rdi+0xc]
+7fa374c2d00a  4881F886DD0000    cmp rax, 0xdd86
+7fa374c2d011  7520              jnz 0x7fa374c2d033
+7fa374c2d013  0FB64714          movzx eax, byte [rdi+0x14]
+7fa374c2d017  4883F82F          cmp rax, +0x2f
+7fa374c2d01b  7419              jz 0x7fa374c2d036
+7fa374c2d01d  4883FE37          cmp rsi, +0x37
+7fa374c2d021  7C10              jl 0x7fa374c2d033
+7fa374c2d023  4883F82C          cmp rax, +0x2c
+7fa374c2d027  750A              jnz 0x7fa374c2d033
+7fa374c2d029  0FB64736          movzx eax, byte [rdi+0x36]
+7fa374c2d02d  4883F82F          cmp rax, +0x2f
+7fa374c2d031  7403              jz 0x7fa374c2d036
+7fa374c2d033  B000              mov al, 0x0
+7fa374c2d035  C3                ret
+7fa374c2d036  B001              mov al, 0x1
+7fa374c2d038  C3                ret
 ```
 

--- a/doc/ip6-proto-ah.md
+++ b/doc/ip6-proto-ah.md
@@ -53,31 +53,29 @@ return function(P,length)
    if v1 ~= 44 then return false end
    return P[54] == 51
 end
-
 ```
 
 ## Native pflang compilation
 
 ```
-7f137adbc000  4883FE36          cmp rsi, +0x36
-7f137adbc004  7C2D              jl 0x7f137adbc033
-7f137adbc006  0FB7470C          movzx eax, word [rdi+0xc]
-7f137adbc00a  4881F886DD0000    cmp rax, 0xdd86
-7f137adbc011  7520              jnz 0x7f137adbc033
-7f137adbc013  0FB64714          movzx eax, byte [rdi+0x14]
-7f137adbc017  4883F833          cmp rax, +0x33
-7f137adbc01b  7419              jz 0x7f137adbc036
-7f137adbc01d  4883FE37          cmp rsi, +0x37
-7f137adbc021  7C10              jl 0x7f137adbc033
-7f137adbc023  4883F82C          cmp rax, +0x2c
-7f137adbc027  750A              jnz 0x7f137adbc033
-7f137adbc029  0FB64736          movzx eax, byte [rdi+0x36]
-7f137adbc02d  4883F833          cmp rax, +0x33
-7f137adbc031  7403              jz 0x7f137adbc036
-7f137adbc033  B000              mov al, 0x0
-7f137adbc035  C3                ret
-7f137adbc036  B001              mov al, 0x1
-7f137adbc038  C3                ret
-
+7f3918edf000  4883FE36          cmp rsi, +0x36
+7f3918edf004  7C2D              jl 0x7f3918edf033
+7f3918edf006  0FB7470C          movzx eax, word [rdi+0xc]
+7f3918edf00a  4881F886DD0000    cmp rax, 0xdd86
+7f3918edf011  7520              jnz 0x7f3918edf033
+7f3918edf013  0FB64714          movzx eax, byte [rdi+0x14]
+7f3918edf017  4883F833          cmp rax, +0x33
+7f3918edf01b  7419              jz 0x7f3918edf036
+7f3918edf01d  4883FE37          cmp rsi, +0x37
+7f3918edf021  7C10              jl 0x7f3918edf033
+7f3918edf023  4883F82C          cmp rax, +0x2c
+7f3918edf027  750A              jnz 0x7f3918edf033
+7f3918edf029  0FB64736          movzx eax, byte [rdi+0x36]
+7f3918edf02d  4883F833          cmp rax, +0x33
+7f3918edf031  7403              jz 0x7f3918edf036
+7f3918edf033  B000              mov al, 0x0
+7f3918edf035  C3                ret
+7f3918edf036  B001              mov al, 0x1
+7f3918edf038  C3                ret
 ```
 

--- a/doc/iso-proto-47.md
+++ b/doc/iso-proto-47.md
@@ -49,29 +49,27 @@ return function(P,length)
    if cast("uint16_t*", P+14)[0] ~= 65278 then return false end
    return P[17] == 47
 end
-
 ```
 
 ## Native pflang compilation
 
 ```
-7fc1c6e25000  4883FE12          cmp rsi, +0x12
-7fc1c6e25004  7C2C              jl 0x7fc1c6e25032
-7fc1c6e25006  0FB7770C          movzx esi, word [rdi+0xc]
-7fc1c6e2500a  66C1CE08          ror si, 0x08
-7fc1c6e2500e  480FB7F6          movzx rsi, si
-7fc1c6e25012  4881FEDC050000    cmp rsi, 0x5dc
-7fc1c6e25019  7F17              jg 0x7fc1c6e25032
-7fc1c6e2501b  0FB7770E          movzx esi, word [rdi+0xe]
-7fc1c6e2501f  4881FEFEFE0000    cmp rsi, 0xfefe
-7fc1c6e25026  750A              jnz 0x7fc1c6e25032
-7fc1c6e25028  0FB67711          movzx esi, byte [rdi+0x11]
-7fc1c6e2502c  4883FE2F          cmp rsi, +0x2f
-7fc1c6e25030  7403              jz 0x7fc1c6e25035
-7fc1c6e25032  B000              mov al, 0x0
-7fc1c6e25034  C3                ret
-7fc1c6e25035  B001              mov al, 0x1
-7fc1c6e25037  C3                ret
-
+7fb85f027000  4883FE12          cmp rsi, +0x12
+7fb85f027004  7C2C              jl 0x7fb85f027032
+7fb85f027006  0FB7770C          movzx esi, word [rdi+0xc]
+7fb85f02700a  66C1CE08          ror si, 0x08
+7fb85f02700e  480FB7F6          movzx rsi, si
+7fb85f027012  4881FEDC050000    cmp rsi, 0x5dc
+7fb85f027019  7F17              jg 0x7fb85f027032
+7fb85f02701b  0FB7770E          movzx esi, word [rdi+0xe]
+7fb85f02701f  4881FEFEFE0000    cmp rsi, 0xfefe
+7fb85f027026  750A              jnz 0x7fb85f027032
+7fb85f027028  0FB67711          movzx esi, byte [rdi+0x11]
+7fb85f02702c  4883FE2F          cmp rsi, +0x2f
+7fb85f027030  7403              jz 0x7fb85f027035
+7fb85f027032  B000              mov al, 0x0
+7fb85f027034  C3                ret
+7fb85f027035  B001              mov al, 0x1
+7fb85f027037  C3                ret
 ```
 

--- a/doc/iso-proto-clnp.md
+++ b/doc/iso-proto-clnp.md
@@ -49,29 +49,27 @@ return function(P,length)
    if cast("uint16_t*", P+14)[0] ~= 65278 then return false end
    return P[17] == 129
 end
-
 ```
 
 ## Native pflang compilation
 
 ```
-7f337c6a5000  4883FE12          cmp rsi, +0x12
-7f337c6a5004  7C2F              jl 0x7f337c6a5035
-7f337c6a5006  0FB7770C          movzx esi, word [rdi+0xc]
-7f337c6a500a  66C1CE08          ror si, 0x08
-7f337c6a500e  480FB7F6          movzx rsi, si
-7f337c6a5012  4881FEDC050000    cmp rsi, 0x5dc
-7f337c6a5019  7F1A              jg 0x7f337c6a5035
-7f337c6a501b  0FB7770E          movzx esi, word [rdi+0xe]
-7f337c6a501f  4881FEFEFE0000    cmp rsi, 0xfefe
-7f337c6a5026  750D              jnz 0x7f337c6a5035
-7f337c6a5028  0FB67711          movzx esi, byte [rdi+0x11]
-7f337c6a502c  4881FE81000000    cmp rsi, 0x81
-7f337c6a5033  7403              jz 0x7f337c6a5038
-7f337c6a5035  B000              mov al, 0x0
-7f337c6a5037  C3                ret
-7f337c6a5038  B001              mov al, 0x1
-7f337c6a503a  C3                ret
-
+7f4b66100000  4883FE12          cmp rsi, +0x12
+7f4b66100004  7C2F              jl 0x7f4b66100035
+7f4b66100006  0FB7770C          movzx esi, word [rdi+0xc]
+7f4b6610000a  66C1CE08          ror si, 0x08
+7f4b6610000e  480FB7F6          movzx rsi, si
+7f4b66100012  4881FEDC050000    cmp rsi, 0x5dc
+7f4b66100019  7F1A              jg 0x7f4b66100035
+7f4b6610001b  0FB7770E          movzx esi, word [rdi+0xe]
+7f4b6610001f  4881FEFEFE0000    cmp rsi, 0xfefe
+7f4b66100026  750D              jnz 0x7f4b66100035
+7f4b66100028  0FB67711          movzx esi, byte [rdi+0x11]
+7f4b6610002c  4881FE81000000    cmp rsi, 0x81
+7f4b66100033  7403              jz 0x7f4b66100038
+7f4b66100035  B000              mov al, 0x0
+7f4b66100037  C3                ret
+7f4b66100038  B001              mov al, 0x1
+7f4b6610003a  C3                ret
 ```
 

--- a/doc/l1.md
+++ b/doc/l1.md
@@ -69,40 +69,38 @@ return function(P,length)
    if v1 == 26 then return true end
    return v1 == 17
 end
-
 ```
 
 ## Native pflang compilation
 
 ```
-7fd7e3943000  4883FE16          cmp rsi, +0x16
-7fd7e3943004  7C51              jl 0x7fd7e3943057
-7fd7e3943006  0FB7770C          movzx esi, word [rdi+0xc]
-7fd7e394300a  66C1CE08          ror si, 0x08
-7fd7e394300e  480FB7F6          movzx rsi, si
-7fd7e3943012  4881FEDC050000    cmp rsi, 0x5dc
-7fd7e3943019  7F3C              jg 0x7fd7e3943057
-7fd7e394301b  0FB7770E          movzx esi, word [rdi+0xe]
-7fd7e394301f  4881FEFEFE0000    cmp rsi, 0xfefe
-7fd7e3943026  752F              jnz 0x7fd7e3943057
-7fd7e3943028  0FB67711          movzx esi, byte [rdi+0x11]
-7fd7e394302c  4881FE83000000    cmp rsi, 0x83
-7fd7e3943033  7522              jnz 0x7fd7e3943057
-7fd7e3943035  0FB67715          movzx esi, byte [rdi+0x15]
-7fd7e3943039  4883FE0F          cmp rsi, +0x0f
-7fd7e394303d  741B              jz 0x7fd7e394305a
-7fd7e394303f  4883FE12          cmp rsi, +0x12
-7fd7e3943043  7415              jz 0x7fd7e394305a
-7fd7e3943045  4883FE18          cmp rsi, +0x18
-7fd7e3943049  740F              jz 0x7fd7e394305a
-7fd7e394304b  4883FE1A          cmp rsi, +0x1a
-7fd7e394304f  7409              jz 0x7fd7e394305a
-7fd7e3943051  4883FE11          cmp rsi, +0x11
-7fd7e3943055  7403              jz 0x7fd7e394305a
-7fd7e3943057  B000              mov al, 0x0
-7fd7e3943059  C3                ret
-7fd7e394305a  B001              mov al, 0x1
-7fd7e394305c  C3                ret
-
+7f87f3428000  4883FE16          cmp rsi, +0x16
+7f87f3428004  7C51              jl 0x7f87f3428057
+7f87f3428006  0FB7770C          movzx esi, word [rdi+0xc]
+7f87f342800a  66C1CE08          ror si, 0x08
+7f87f342800e  480FB7F6          movzx rsi, si
+7f87f3428012  4881FEDC050000    cmp rsi, 0x5dc
+7f87f3428019  7F3C              jg 0x7f87f3428057
+7f87f342801b  0FB7770E          movzx esi, word [rdi+0xe]
+7f87f342801f  4881FEFEFE0000    cmp rsi, 0xfefe
+7f87f3428026  752F              jnz 0x7f87f3428057
+7f87f3428028  0FB67711          movzx esi, byte [rdi+0x11]
+7f87f342802c  4881FE83000000    cmp rsi, 0x83
+7f87f3428033  7522              jnz 0x7f87f3428057
+7f87f3428035  0FB67715          movzx esi, byte [rdi+0x15]
+7f87f3428039  4883FE0F          cmp rsi, +0x0f
+7f87f342803d  741B              jz 0x7f87f342805a
+7f87f342803f  4883FE12          cmp rsi, +0x12
+7f87f3428043  7415              jz 0x7f87f342805a
+7f87f3428045  4883FE18          cmp rsi, +0x18
+7f87f3428049  740F              jz 0x7f87f342805a
+7f87f342804b  4883FE1A          cmp rsi, +0x1a
+7f87f342804f  7409              jz 0x7f87f342805a
+7f87f3428051  4883FE11          cmp rsi, +0x11
+7f87f3428055  7403              jz 0x7f87f342805a
+7f87f3428057  B000              mov al, 0x0
+7f87f3428059  C3                ret
+7f87f342805a  B001              mov al, 0x1
+7f87f342805c  C3                ret
 ```
 

--- a/doc/net-127.0.0.0-8.md
+++ b/doc/net-127.0.0.0-8.md
@@ -86,44 +86,42 @@ return function(P,length)
       return band(cast("uint32_t*", P+38)[0],255) == 127
    end
 end
-
 ```
 
 ## Native pflang compilation
 
 ```
-7fa5ddcb5000  4883FE22          cmp rsi, +0x22
-7fa5ddcb5004  0F8C64000000      jl 0x7fa5ddcb506e
-7fa5ddcb500a  0FB7470C          movzx eax, word [rdi+0xc]
-7fa5ddcb500e  4883F808          cmp rax, +0x08
-7fa5ddcb5012  7522              jnz 0x7fa5ddcb5036
-7fa5ddcb5014  8B4F1A            mov ecx, [rdi+0x1a]
-7fa5ddcb5017  4881E1FF000000    and rcx, 0xff
-7fa5ddcb501e  4883F97F          cmp rcx, +0x7f
-7fa5ddcb5022  744D              jz 0x7fa5ddcb5071
-7fa5ddcb5024  8B4F1E            mov ecx, [rdi+0x1e]
-7fa5ddcb5027  4881E1FF000000    and rcx, 0xff
-7fa5ddcb502e  4883F97F          cmp rcx, +0x7f
-7fa5ddcb5032  743D              jz 0x7fa5ddcb5071
-7fa5ddcb5034  EB38              jmp 0x7fa5ddcb506e
-7fa5ddcb5036  4883FE2A          cmp rsi, +0x2a
-7fa5ddcb503a  7C32              jl 0x7fa5ddcb506e
-7fa5ddcb503c  4881F808060000    cmp rax, 0x608
-7fa5ddcb5043  7409              jz 0x7fa5ddcb504e
-7fa5ddcb5045  4881F880350000    cmp rax, 0x3580
-7fa5ddcb504c  7520              jnz 0x7fa5ddcb506e
-7fa5ddcb504e  8B471C            mov eax, [rdi+0x1c]
-7fa5ddcb5051  4881E0FF000000    and rax, 0xff
-7fa5ddcb5058  4883F87F          cmp rax, +0x7f
-7fa5ddcb505c  7413              jz 0x7fa5ddcb5071
-7fa5ddcb505e  8B4726            mov eax, [rdi+0x26]
-7fa5ddcb5061  4881E0FF000000    and rax, 0xff
-7fa5ddcb5068  4883F87F          cmp rax, +0x7f
-7fa5ddcb506c  7403              jz 0x7fa5ddcb5071
-7fa5ddcb506e  B000              mov al, 0x0
-7fa5ddcb5070  C3                ret
-7fa5ddcb5071  B001              mov al, 0x1
-7fa5ddcb5073  C3                ret
-
+7f4e59c5c000  4883FE22          cmp rsi, +0x22
+7f4e59c5c004  0F8C64000000      jl 0x7f4e59c5c06e
+7f4e59c5c00a  0FB7470C          movzx eax, word [rdi+0xc]
+7f4e59c5c00e  4883F808          cmp rax, +0x08
+7f4e59c5c012  7522              jnz 0x7f4e59c5c036
+7f4e59c5c014  8B4F1A            mov ecx, [rdi+0x1a]
+7f4e59c5c017  4881E1FF000000    and rcx, 0xff
+7f4e59c5c01e  4883F97F          cmp rcx, +0x7f
+7f4e59c5c022  744D              jz 0x7f4e59c5c071
+7f4e59c5c024  8B4F1E            mov ecx, [rdi+0x1e]
+7f4e59c5c027  4881E1FF000000    and rcx, 0xff
+7f4e59c5c02e  4883F97F          cmp rcx, +0x7f
+7f4e59c5c032  743D              jz 0x7f4e59c5c071
+7f4e59c5c034  EB38              jmp 0x7f4e59c5c06e
+7f4e59c5c036  4883FE2A          cmp rsi, +0x2a
+7f4e59c5c03a  7C32              jl 0x7f4e59c5c06e
+7f4e59c5c03c  4881F808060000    cmp rax, 0x608
+7f4e59c5c043  7409              jz 0x7f4e59c5c04e
+7f4e59c5c045  4881F880350000    cmp rax, 0x3580
+7f4e59c5c04c  7520              jnz 0x7f4e59c5c06e
+7f4e59c5c04e  8B471C            mov eax, [rdi+0x1c]
+7f4e59c5c051  4881E0FF000000    and rax, 0xff
+7f4e59c5c058  4883F87F          cmp rax, +0x7f
+7f4e59c5c05c  7413              jz 0x7f4e59c5c071
+7f4e59c5c05e  8B4726            mov eax, [rdi+0x26]
+7f4e59c5c061  4881E0FF000000    and rax, 0xff
+7f4e59c5c068  4883F87F          cmp rax, +0x7f
+7f4e59c5c06c  7403              jz 0x7f4e59c5c071
+7f4e59c5c06e  B000              mov al, 0x0
+7f4e59c5c070  C3                ret
+7f4e59c5c071  B001              mov al, 0x1
+7f4e59c5c073  C3                ret
 ```
 

--- a/doc/net-ipv6-0-mask-16.md
+++ b/doc/net-ipv6-0-mask-16.md
@@ -49,29 +49,27 @@ return function(P,length)
    if band(cast("uint32_t*", P+22)[0],65535) == 0 then return true end
    return band(cast("uint32_t*", P+38)[0],65535) == 0
 end
-
 ```
 
 ## Native pflang compilation
 
 ```
-7f3bd715d000  4883FE36          cmp rsi, +0x36
-7f3bd715d004  7C2D              jl 0x7f3bd715d033
-7f3bd715d006  0FB7770C          movzx esi, word [rdi+0xc]
-7f3bd715d00a  4881FE86DD0000    cmp rsi, 0xdd86
-7f3bd715d011  7520              jnz 0x7f3bd715d033
-7f3bd715d013  8B7716            mov esi, [rdi+0x16]
-7f3bd715d016  4881E6FFFF0000    and rsi, 0xffff
-7f3bd715d01d  4883FE00          cmp rsi, +0x00
-7f3bd715d021  7413              jz 0x7f3bd715d036
-7f3bd715d023  8B7726            mov esi, [rdi+0x26]
-7f3bd715d026  4881E6FFFF0000    and rsi, 0xffff
-7f3bd715d02d  4883FE00          cmp rsi, +0x00
-7f3bd715d031  7403              jz 0x7f3bd715d036
-7f3bd715d033  B000              mov al, 0x0
-7f3bd715d035  C3                ret
-7f3bd715d036  B001              mov al, 0x1
-7f3bd715d038  C3                ret
-
+7f505b47e000  4883FE36          cmp rsi, +0x36
+7f505b47e004  7C2D              jl 0x7f505b47e033
+7f505b47e006  0FB7770C          movzx esi, word [rdi+0xc]
+7f505b47e00a  4881FE86DD0000    cmp rsi, 0xdd86
+7f505b47e011  7520              jnz 0x7f505b47e033
+7f505b47e013  8B7716            mov esi, [rdi+0x16]
+7f505b47e016  4881E6FFFF0000    and rsi, 0xffff
+7f505b47e01d  4883FE00          cmp rsi, +0x00
+7f505b47e021  7413              jz 0x7f505b47e036
+7f505b47e023  8B7726            mov esi, [rdi+0x26]
+7f505b47e026  4881E6FFFF0000    and rsi, 0xffff
+7f505b47e02d  4883FE00          cmp rsi, +0x00
+7f505b47e031  7403              jz 0x7f505b47e036
+7f505b47e033  B000              mov al, 0x0
+7f505b47e035  C3                ret
+7f505b47e036  B001              mov al, 0x1
+7f505b47e038  C3                ret
 ```
 

--- a/doc/net-ipv6-ee.cc.9954.0-mask-111.md
+++ b/doc/net-ipv6-ee.cc.9954.0-mask-111.md
@@ -94,49 +94,47 @@ return function(P,length)
    if cast("uint32_t*", P+46)[0] ~= 0 then return false end
    return band(cast("uint32_t*", P+50)[0],65279) == 21657
 end
-
 ```
 
 ## Native pflang compilation
 
 ```
-7f62aa975000  4883FE36          cmp rsi, +0x36
-7f62aa975004  0F8C7F000000      jl 0x7f62aa975089
-7f62aa97500a  0FB7770C          movzx esi, word [rdi+0xc]
-7f62aa97500e  4881FE86DD0000    cmp rsi, 0xdd86
-7f62aa975015  0F856E000000      jnz 0x7f62aa975089
-7f62aa97501b  8B7716            mov esi, [rdi+0x16]
-7f62aa97501e  48B800EE00CC0000. mov rax, 0x00000000cc00ee00
-7f62aa975028  4839C6            cmp rsi, rax
-7f62aa97502b  7525              jnz 0x7f62aa975052
-7f62aa97502d  8B471A            mov eax, [rdi+0x1a]
-7f62aa975030  4883F800          cmp rax, +0x00
-7f62aa975034  751C              jnz 0x7f62aa975052
-7f62aa975036  8B471E            mov eax, [rdi+0x1e]
-7f62aa975039  4883F800          cmp rax, +0x00
-7f62aa97503d  7513              jnz 0x7f62aa975052
-7f62aa97503f  8B4722            mov eax, [rdi+0x22]
-7f62aa975042  4881E0FFFE0000    and rax, 0xfeff
-7f62aa975049  4881F899540000    cmp rax, 0x5499
-7f62aa975050  743A              jz 0x7f62aa97508c
-7f62aa975052  8B4726            mov eax, [rdi+0x26]
-7f62aa975055  48BE00EE00CC0000. mov rsi, 0x00000000cc00ee00
-7f62aa97505f  4839F0            cmp rax, rsi
-7f62aa975062  7525              jnz 0x7f62aa975089
-7f62aa975064  8B772A            mov esi, [rdi+0x2a]
-7f62aa975067  4883FE00          cmp rsi, +0x00
-7f62aa97506b  751C              jnz 0x7f62aa975089
-7f62aa97506d  8B772E            mov esi, [rdi+0x2e]
-7f62aa975070  4883FE00          cmp rsi, +0x00
-7f62aa975074  7513              jnz 0x7f62aa975089
-7f62aa975076  8B7732            mov esi, [rdi+0x32]
-7f62aa975079  4881E6FFFE0000    and rsi, 0xfeff
-7f62aa975080  4881FE99540000    cmp rsi, 0x5499
-7f62aa975087  7403              jz 0x7f62aa97508c
-7f62aa975089  B000              mov al, 0x0
-7f62aa97508b  C3                ret
-7f62aa97508c  B001              mov al, 0x1
-7f62aa97508e  C3                ret
-
+7f0865825000  4883FE36          cmp rsi, +0x36
+7f0865825004  0F8C7F000000      jl 0x7f0865825089
+7f086582500a  0FB7770C          movzx esi, word [rdi+0xc]
+7f086582500e  4881FE86DD0000    cmp rsi, 0xdd86
+7f0865825015  0F856E000000      jnz 0x7f0865825089
+7f086582501b  8B7716            mov esi, [rdi+0x16]
+7f086582501e  48B800EE00CC0000. mov rax, 0x00000000cc00ee00
+7f0865825028  4839C6            cmp rsi, rax
+7f086582502b  7525              jnz 0x7f0865825052
+7f086582502d  8B471A            mov eax, [rdi+0x1a]
+7f0865825030  4883F800          cmp rax, +0x00
+7f0865825034  751C              jnz 0x7f0865825052
+7f0865825036  8B471E            mov eax, [rdi+0x1e]
+7f0865825039  4883F800          cmp rax, +0x00
+7f086582503d  7513              jnz 0x7f0865825052
+7f086582503f  8B4722            mov eax, [rdi+0x22]
+7f0865825042  4881E0FFFE0000    and rax, 0xfeff
+7f0865825049  4881F899540000    cmp rax, 0x5499
+7f0865825050  743A              jz 0x7f086582508c
+7f0865825052  8B4726            mov eax, [rdi+0x26]
+7f0865825055  48BE00EE00CC0000. mov rsi, 0x00000000cc00ee00
+7f086582505f  4839F0            cmp rax, rsi
+7f0865825062  7525              jnz 0x7f0865825089
+7f0865825064  8B772A            mov esi, [rdi+0x2a]
+7f0865825067  4883FE00          cmp rsi, +0x00
+7f086582506b  751C              jnz 0x7f0865825089
+7f086582506d  8B772E            mov esi, [rdi+0x2e]
+7f0865825070  4883FE00          cmp rsi, +0x00
+7f0865825074  7513              jnz 0x7f0865825089
+7f0865825076  8B7732            mov esi, [rdi+0x32]
+7f0865825079  4881E6FFFE0000    and rsi, 0xfeff
+7f0865825080  4881FE99540000    cmp rsi, 0x5499
+7f0865825087  7403              jz 0x7f086582508c
+7f0865825089  B000              mov al, 0x0
+7f086582508b  C3                ret
+7f086582508c  B001              mov al, 0x1
+7f086582508e  C3                ret
 ```
 

--- a/doc/packet-access-igmp.md
+++ b/doc/packet-access-igmp.md
@@ -63,39 +63,37 @@ return function(P,length)
    if (v1 + 23) > length then return false end
    return P[(v1 + 22)] < 8
 end
-
 ```
 
 ## Native pflang compilation
 
 ```
-7ff867b83000  4883FE2A          cmp rsi, +0x2a
-7ff867b83004  7C4A              jl 0x7ff867b83050
-7ff867b83006  0FB7470C          movzx eax, word [rdi+0xc]
-7ff867b8300a  4883F808          cmp rax, +0x08
-7ff867b8300e  7540              jnz 0x7ff867b83050
-7ff867b83010  0FB64717          movzx eax, byte [rdi+0x17]
-7ff867b83014  4883F802          cmp rax, +0x02
-7ff867b83018  7536              jnz 0x7ff867b83050
-7ff867b8301a  0FB74714          movzx eax, word [rdi+0x14]
-7ff867b8301e  4881E01FFF0000    and rax, 0xff1f
-7ff867b83025  4883F800          cmp rax, +0x00
-7ff867b83029  7525              jnz 0x7ff867b83050
-7ff867b8302b  0FB6470E          movzx eax, byte [rdi+0xe]
-7ff867b8302f  4883E00F          and rax, +0x0f
-7ff867b83033  48C1E002          shl rax, 0x02
-7ff867b83037  89C1              mov ecx, eax
-7ff867b83039  4883C117          add rcx, +0x17
-7ff867b8303d  4839F1            cmp rcx, rsi
-7ff867b83040  7F0E              jg 0x7ff867b83050
-7ff867b83042  4883C016          add rax, +0x16
-7ff867b83046  0FB60407          movzx eax, byte [rdi+rax]
-7ff867b8304a  4883F808          cmp rax, +0x08
-7ff867b8304e  7C03              jl 0x7ff867b83053
-7ff867b83050  B000              mov al, 0x0
-7ff867b83052  C3                ret
-7ff867b83053  B001              mov al, 0x1
-7ff867b83055  C3                ret
-
+7f9b8781c000  4883FE2A          cmp rsi, +0x2a
+7f9b8781c004  7C4A              jl 0x7f9b8781c050
+7f9b8781c006  0FB7470C          movzx eax, word [rdi+0xc]
+7f9b8781c00a  4883F808          cmp rax, +0x08
+7f9b8781c00e  7540              jnz 0x7f9b8781c050
+7f9b8781c010  0FB64717          movzx eax, byte [rdi+0x17]
+7f9b8781c014  4883F802          cmp rax, +0x02
+7f9b8781c018  7536              jnz 0x7f9b8781c050
+7f9b8781c01a  0FB74714          movzx eax, word [rdi+0x14]
+7f9b8781c01e  4881E01FFF0000    and rax, 0xff1f
+7f9b8781c025  4883F800          cmp rax, +0x00
+7f9b8781c029  7525              jnz 0x7f9b8781c050
+7f9b8781c02b  0FB6470E          movzx eax, byte [rdi+0xe]
+7f9b8781c02f  4883E00F          and rax, +0x0f
+7f9b8781c033  48C1E002          shl rax, 0x02
+7f9b8781c037  89C1              mov ecx, eax
+7f9b8781c039  4883C117          add rcx, +0x17
+7f9b8781c03d  4839F1            cmp rcx, rsi
+7f9b8781c040  7F0E              jg 0x7f9b8781c050
+7f9b8781c042  4883C016          add rax, +0x16
+7f9b8781c046  0FB60407          movzx eax, byte [rdi+rax]
+7f9b8781c04a  4883F808          cmp rax, +0x08
+7f9b8781c04e  7C03              jl 0x7f9b8781c053
+7f9b8781c050  B000              mov al, 0x0
+7f9b8781c052  C3                ret
+7f9b8781c053  B001              mov al, 0x1
+7f9b8781c055  C3                ret
 ```
 

--- a/doc/packet-access-igrp.md
+++ b/doc/packet-access-igrp.md
@@ -63,39 +63,37 @@ return function(P,length)
    if (v1 + 23) > length then return false end
    return P[(v1 + 22)] < 8
 end
-
 ```
 
 ## Native pflang compilation
 
 ```
-7fc86d79f000  4883FE2A          cmp rsi, +0x2a
-7fc86d79f004  7C4A              jl 0x7fc86d79f050
-7fc86d79f006  0FB7470C          movzx eax, word [rdi+0xc]
-7fc86d79f00a  4883F808          cmp rax, +0x08
-7fc86d79f00e  7540              jnz 0x7fc86d79f050
-7fc86d79f010  0FB64717          movzx eax, byte [rdi+0x17]
-7fc86d79f014  4883F809          cmp rax, +0x09
-7fc86d79f018  7536              jnz 0x7fc86d79f050
-7fc86d79f01a  0FB74714          movzx eax, word [rdi+0x14]
-7fc86d79f01e  4881E01FFF0000    and rax, 0xff1f
-7fc86d79f025  4883F800          cmp rax, +0x00
-7fc86d79f029  7525              jnz 0x7fc86d79f050
-7fc86d79f02b  0FB6470E          movzx eax, byte [rdi+0xe]
-7fc86d79f02f  4883E00F          and rax, +0x0f
-7fc86d79f033  48C1E002          shl rax, 0x02
-7fc86d79f037  89C1              mov ecx, eax
-7fc86d79f039  4883C117          add rcx, +0x17
-7fc86d79f03d  4839F1            cmp rcx, rsi
-7fc86d79f040  7F0E              jg 0x7fc86d79f050
-7fc86d79f042  4883C016          add rax, +0x16
-7fc86d79f046  0FB60407          movzx eax, byte [rdi+rax]
-7fc86d79f04a  4883F808          cmp rax, +0x08
-7fc86d79f04e  7C03              jl 0x7fc86d79f053
-7fc86d79f050  B000              mov al, 0x0
-7fc86d79f052  C3                ret
-7fc86d79f053  B001              mov al, 0x1
-7fc86d79f055  C3                ret
-
+7f6e99147000  4883FE2A          cmp rsi, +0x2a
+7f6e99147004  7C4A              jl 0x7f6e99147050
+7f6e99147006  0FB7470C          movzx eax, word [rdi+0xc]
+7f6e9914700a  4883F808          cmp rax, +0x08
+7f6e9914700e  7540              jnz 0x7f6e99147050
+7f6e99147010  0FB64717          movzx eax, byte [rdi+0x17]
+7f6e99147014  4883F809          cmp rax, +0x09
+7f6e99147018  7536              jnz 0x7f6e99147050
+7f6e9914701a  0FB74714          movzx eax, word [rdi+0x14]
+7f6e9914701e  4881E01FFF0000    and rax, 0xff1f
+7f6e99147025  4883F800          cmp rax, +0x00
+7f6e99147029  7525              jnz 0x7f6e99147050
+7f6e9914702b  0FB6470E          movzx eax, byte [rdi+0xe]
+7f6e9914702f  4883E00F          and rax, +0x0f
+7f6e99147033  48C1E002          shl rax, 0x02
+7f6e99147037  89C1              mov ecx, eax
+7f6e99147039  4883C117          add rcx, +0x17
+7f6e9914703d  4839F1            cmp rcx, rsi
+7f6e99147040  7F0E              jg 0x7f6e99147050
+7f6e99147042  4883C016          add rax, +0x16
+7f6e99147046  0FB60407          movzx eax, byte [rdi+rax]
+7f6e9914704a  4883F808          cmp rax, +0x08
+7f6e9914704e  7C03              jl 0x7f6e99147053
+7f6e99147050  B000              mov al, 0x0
+7f6e99147052  C3                ret
+7f6e99147053  B001              mov al, 0x1
+7f6e99147055  C3                ret
 ```
 

--- a/doc/packet-access-pim.md
+++ b/doc/packet-access-pim.md
@@ -63,39 +63,37 @@ return function(P,length)
    if (v1 + 23) > length then return false end
    return P[(v1 + 22)] < 8
 end
-
 ```
 
 ## Native pflang compilation
 
 ```
-7f44142b9000  4883FE26          cmp rsi, +0x26
-7f44142b9004  7C4A              jl 0x7f44142b9050
-7f44142b9006  0FB7470C          movzx eax, word [rdi+0xc]
-7f44142b900a  4883F808          cmp rax, +0x08
-7f44142b900e  7540              jnz 0x7f44142b9050
-7f44142b9010  0FB64717          movzx eax, byte [rdi+0x17]
-7f44142b9014  4883F867          cmp rax, +0x67
-7f44142b9018  7536              jnz 0x7f44142b9050
-7f44142b901a  0FB74714          movzx eax, word [rdi+0x14]
-7f44142b901e  4881E01FFF0000    and rax, 0xff1f
-7f44142b9025  4883F800          cmp rax, +0x00
-7f44142b9029  7525              jnz 0x7f44142b9050
-7f44142b902b  0FB6470E          movzx eax, byte [rdi+0xe]
-7f44142b902f  4883E00F          and rax, +0x0f
-7f44142b9033  48C1E002          shl rax, 0x02
-7f44142b9037  89C1              mov ecx, eax
-7f44142b9039  4883C117          add rcx, +0x17
-7f44142b903d  4839F1            cmp rcx, rsi
-7f44142b9040  7F0E              jg 0x7f44142b9050
-7f44142b9042  4883C016          add rax, +0x16
-7f44142b9046  0FB60407          movzx eax, byte [rdi+rax]
-7f44142b904a  4883F808          cmp rax, +0x08
-7f44142b904e  7C03              jl 0x7f44142b9053
-7f44142b9050  B000              mov al, 0x0
-7f44142b9052  C3                ret
-7f44142b9053  B001              mov al, 0x1
-7f44142b9055  C3                ret
-
+7fdf62f4e000  4883FE26          cmp rsi, +0x26
+7fdf62f4e004  7C4A              jl 0x7fdf62f4e050
+7fdf62f4e006  0FB7470C          movzx eax, word [rdi+0xc]
+7fdf62f4e00a  4883F808          cmp rax, +0x08
+7fdf62f4e00e  7540              jnz 0x7fdf62f4e050
+7fdf62f4e010  0FB64717          movzx eax, byte [rdi+0x17]
+7fdf62f4e014  4883F867          cmp rax, +0x67
+7fdf62f4e018  7536              jnz 0x7fdf62f4e050
+7fdf62f4e01a  0FB74714          movzx eax, word [rdi+0x14]
+7fdf62f4e01e  4881E01FFF0000    and rax, 0xff1f
+7fdf62f4e025  4883F800          cmp rax, +0x00
+7fdf62f4e029  7525              jnz 0x7fdf62f4e050
+7fdf62f4e02b  0FB6470E          movzx eax, byte [rdi+0xe]
+7fdf62f4e02f  4883E00F          and rax, +0x0f
+7fdf62f4e033  48C1E002          shl rax, 0x02
+7fdf62f4e037  89C1              mov ecx, eax
+7fdf62f4e039  4883C117          add rcx, +0x17
+7fdf62f4e03d  4839F1            cmp rcx, rsi
+7fdf62f4e040  7F0E              jg 0x7fdf62f4e050
+7fdf62f4e042  4883C016          add rax, +0x16
+7fdf62f4e046  0FB60407          movzx eax, byte [rdi+rax]
+7fdf62f4e04a  4883F808          cmp rax, +0x08
+7fdf62f4e04e  7C03              jl 0x7fdf62f4e053
+7fdf62f4e050  B000              mov al, 0x0
+7fdf62f4e052  C3                ret
+7fdf62f4e053  B001              mov al, 0x1
+7fdf62f4e055  C3                ret
 ```
 

--- a/doc/packet-access-sctp.md
+++ b/doc/packet-access-sctp.md
@@ -63,39 +63,37 @@ return function(P,length)
    if (v1 + 23) > length then return false end
    return P[(v1 + 22)] < 8
 end
-
 ```
 
 ## Native pflang compilation
 
 ```
-7f54e27d9000  4883FE2E          cmp rsi, +0x2e
-7f54e27d9004  7C4D              jl 0x7f54e27d9053
-7f54e27d9006  0FB7470C          movzx eax, word [rdi+0xc]
-7f54e27d900a  4883F808          cmp rax, +0x08
-7f54e27d900e  7543              jnz 0x7f54e27d9053
-7f54e27d9010  0FB64717          movzx eax, byte [rdi+0x17]
-7f54e27d9014  4881F884000000    cmp rax, 0x84
-7f54e27d901b  7536              jnz 0x7f54e27d9053
-7f54e27d901d  0FB74714          movzx eax, word [rdi+0x14]
-7f54e27d9021  4881E01FFF0000    and rax, 0xff1f
-7f54e27d9028  4883F800          cmp rax, +0x00
-7f54e27d902c  7525              jnz 0x7f54e27d9053
-7f54e27d902e  0FB6470E          movzx eax, byte [rdi+0xe]
-7f54e27d9032  4883E00F          and rax, +0x0f
-7f54e27d9036  48C1E002          shl rax, 0x02
-7f54e27d903a  89C1              mov ecx, eax
-7f54e27d903c  4883C117          add rcx, +0x17
-7f54e27d9040  4839F1            cmp rcx, rsi
-7f54e27d9043  7F0E              jg 0x7f54e27d9053
-7f54e27d9045  4883C016          add rax, +0x16
-7f54e27d9049  0FB60407          movzx eax, byte [rdi+rax]
-7f54e27d904d  4883F808          cmp rax, +0x08
-7f54e27d9051  7C03              jl 0x7f54e27d9056
-7f54e27d9053  B000              mov al, 0x0
-7f54e27d9055  C3                ret
-7f54e27d9056  B001              mov al, 0x1
-7f54e27d9058  C3                ret
-
+7ff8b99b3000  4883FE2E          cmp rsi, +0x2e
+7ff8b99b3004  7C4D              jl 0x7ff8b99b3053
+7ff8b99b3006  0FB7470C          movzx eax, word [rdi+0xc]
+7ff8b99b300a  4883F808          cmp rax, +0x08
+7ff8b99b300e  7543              jnz 0x7ff8b99b3053
+7ff8b99b3010  0FB64717          movzx eax, byte [rdi+0x17]
+7ff8b99b3014  4881F884000000    cmp rax, 0x84
+7ff8b99b301b  7536              jnz 0x7ff8b99b3053
+7ff8b99b301d  0FB74714          movzx eax, word [rdi+0x14]
+7ff8b99b3021  4881E01FFF0000    and rax, 0xff1f
+7ff8b99b3028  4883F800          cmp rax, +0x00
+7ff8b99b302c  7525              jnz 0x7ff8b99b3053
+7ff8b99b302e  0FB6470E          movzx eax, byte [rdi+0xe]
+7ff8b99b3032  4883E00F          and rax, +0x0f
+7ff8b99b3036  48C1E002          shl rax, 0x02
+7ff8b99b303a  89C1              mov ecx, eax
+7ff8b99b303c  4883C117          add rcx, +0x17
+7ff8b99b3040  4839F1            cmp rcx, rsi
+7ff8b99b3043  7F0E              jg 0x7ff8b99b3053
+7ff8b99b3045  4883C016          add rax, +0x16
+7ff8b99b3049  0FB60407          movzx eax, byte [rdi+rax]
+7ff8b99b304d  4883F808          cmp rax, +0x08
+7ff8b99b3051  7C03              jl 0x7ff8b99b3056
+7ff8b99b3053  B000              mov al, 0x0
+7ff8b99b3055  C3                ret
+7ff8b99b3056  B001              mov al, 0x1
+7ff8b99b3058  C3                ret
 ```
 

--- a/doc/packet-access-vrrp.md
+++ b/doc/packet-access-vrrp.md
@@ -63,39 +63,37 @@ return function(P,length)
    if (v1 + 23) > length then return false end
    return P[(v1 + 22)] < 8
 end
-
 ```
 
 ## Native pflang compilation
 
 ```
-7f20130d7000  4883FE2A          cmp rsi, +0x2a
-7f20130d7004  7C4A              jl 0x7f20130d7050
-7f20130d7006  0FB7470C          movzx eax, word [rdi+0xc]
-7f20130d700a  4883F808          cmp rax, +0x08
-7f20130d700e  7540              jnz 0x7f20130d7050
-7f20130d7010  0FB64717          movzx eax, byte [rdi+0x17]
-7f20130d7014  4883F870          cmp rax, +0x70
-7f20130d7018  7536              jnz 0x7f20130d7050
-7f20130d701a  0FB74714          movzx eax, word [rdi+0x14]
-7f20130d701e  4881E01FFF0000    and rax, 0xff1f
-7f20130d7025  4883F800          cmp rax, +0x00
-7f20130d7029  7525              jnz 0x7f20130d7050
-7f20130d702b  0FB6470E          movzx eax, byte [rdi+0xe]
-7f20130d702f  4883E00F          and rax, +0x0f
-7f20130d7033  48C1E002          shl rax, 0x02
-7f20130d7037  89C1              mov ecx, eax
-7f20130d7039  4883C117          add rcx, +0x17
-7f20130d703d  4839F1            cmp rcx, rsi
-7f20130d7040  7F0E              jg 0x7f20130d7050
-7f20130d7042  4883C016          add rax, +0x16
-7f20130d7046  0FB60407          movzx eax, byte [rdi+rax]
-7f20130d704a  4883F808          cmp rax, +0x08
-7f20130d704e  7C03              jl 0x7f20130d7053
-7f20130d7050  B000              mov al, 0x0
-7f20130d7052  C3                ret
-7f20130d7053  B001              mov al, 0x1
-7f20130d7055  C3                ret
-
+7f0490f27000  4883FE2A          cmp rsi, +0x2a
+7f0490f27004  7C4A              jl 0x7f0490f27050
+7f0490f27006  0FB7470C          movzx eax, word [rdi+0xc]
+7f0490f2700a  4883F808          cmp rax, +0x08
+7f0490f2700e  7540              jnz 0x7f0490f27050
+7f0490f27010  0FB64717          movzx eax, byte [rdi+0x17]
+7f0490f27014  4883F870          cmp rax, +0x70
+7f0490f27018  7536              jnz 0x7f0490f27050
+7f0490f2701a  0FB74714          movzx eax, word [rdi+0x14]
+7f0490f2701e  4881E01FFF0000    and rax, 0xff1f
+7f0490f27025  4883F800          cmp rax, +0x00
+7f0490f27029  7525              jnz 0x7f0490f27050
+7f0490f2702b  0FB6470E          movzx eax, byte [rdi+0xe]
+7f0490f2702f  4883E00F          and rax, +0x0f
+7f0490f27033  48C1E002          shl rax, 0x02
+7f0490f27037  89C1              mov ecx, eax
+7f0490f27039  4883C117          add rcx, +0x17
+7f0490f2703d  4839F1            cmp rcx, rsi
+7f0490f27040  7F0E              jg 0x7f0490f27050
+7f0490f27042  4883C016          add rax, +0x16
+7f0490f27046  0FB60407          movzx eax, byte [rdi+rax]
+7f0490f2704a  4883F808          cmp rax, +0x08
+7f0490f2704e  7C03              jl 0x7f0490f27053
+7f0490f27050  B000              mov al, 0x0
+7f0490f27052  C3                ret
+7f0490f27053  B001              mov al, 0x1
+7f0490f27055  C3                ret
 ```
 

--- a/doc/portrange-0-6000.md
+++ b/doc/portrange-0-6000.md
@@ -150,93 +150,91 @@ return function(P,length)
       return rshift(bswap(cast("uint16_t*", P+56)[0]), 16) <= 6000
    end
 end
-
 ```
 
 ## Native pflang compilation
 
 ```
-7f88b8151000  4883FE22          cmp rsi, +0x22
-7f88b8151004  0F8C3B010000      jl 0x7f88b8151145
-7f88b815100a  0FB7470C          movzx eax, word [rdi+0xc]
-7f88b815100e  4883F808          cmp rax, +0x08
-7f88b8151012  0F859A000000      jnz 0x7f88b81510b2
-7f88b8151018  0FB64F17          movzx ecx, byte [rdi+0x17]
-7f88b815101c  4883F906          cmp rcx, +0x06
-7f88b8151020  7413              jz 0x7f88b8151035
-7f88b8151022  4883F911          cmp rcx, +0x11
-7f88b8151026  740D              jz 0x7f88b8151035
-7f88b8151028  4881F984000000    cmp rcx, 0x84
-7f88b815102f  0F8510010000      jnz 0x7f88b8151145
-7f88b8151035  0FB74F14          movzx ecx, word [rdi+0x14]
-7f88b8151039  4881E11FFF0000    and rcx, 0xff1f
-7f88b8151040  4883F900          cmp rcx, +0x00
-7f88b8151044  0F85FB000000      jnz 0x7f88b8151145
-7f88b815104a  0FB64F0E          movzx ecx, byte [rdi+0xe]
-7f88b815104e  4883E10F          and rcx, +0x0f
-7f88b8151052  48C1E102          shl rcx, 0x02
-7f88b8151056  89CA              mov edx, ecx
-7f88b8151058  4883C210          add rdx, +0x10
-7f88b815105c  4839F2            cmp rdx, rsi
-7f88b815105f  0F8FE0000000      jg 0x7f88b8151145
-7f88b8151065  4189C8            mov r8d, ecx
-7f88b8151068  4983C00E          add r8, +0x0e
-7f88b815106c  460FB70407        movzx r8d, word [rdi+r8]
-7f88b8151071  6641C1C808        ror r8w, 0x08
-7f88b8151076  4D0FB7C0          movzx r8, r8w
-7f88b815107a  4981F870170000    cmp r8, 0x1770
-7f88b8151081  0F8EC1000000      jle 0x7f88b8151148
-7f88b8151087  4883C112          add rcx, +0x12
-7f88b815108b  4839F1            cmp rcx, rsi
-7f88b815108e  0F8FB1000000      jg 0x7f88b8151145
-7f88b8151094  0FB71417          movzx edx, word [rdi+rdx]
-7f88b8151098  66C1CA08          ror dx, 0x08
-7f88b815109c  480FB7D2          movzx rdx, dx
-7f88b81510a0  4881FA70170000    cmp rdx, 0x1770
-7f88b81510a7  0F8E9B000000      jle 0x7f88b8151148
-7f88b81510ad  E993000000        jmp 0x7f88b8151145
-7f88b81510b2  4883FE38          cmp rsi, +0x38
-7f88b81510b6  0F8C89000000      jl 0x7f88b8151145
-7f88b81510bc  4881F886DD0000    cmp rax, 0xdd86
-7f88b81510c3  0F857C000000      jnz 0x7f88b8151145
-7f88b81510c9  0FB64714          movzx eax, byte [rdi+0x14]
-7f88b81510cd  4883F806          cmp rax, +0x06
-7f88b81510d1  7442              jz 0x7f88b8151115
-7f88b81510d3  4883F82C          cmp rax, +0x2c
-7f88b81510d7  750A              jnz 0x7f88b81510e3
-7f88b81510d9  0FB65736          movzx edx, byte [rdi+0x36]
-7f88b81510dd  4883FA06          cmp rdx, +0x06
-7f88b81510e1  7432              jz 0x7f88b8151115
-7f88b81510e3  4883F811          cmp rax, +0x11
-7f88b81510e7  742C              jz 0x7f88b8151115
-7f88b81510e9  4883F82C          cmp rax, +0x2c
-7f88b81510ed  750A              jnz 0x7f88b81510f9
-7f88b81510ef  0FB65736          movzx edx, byte [rdi+0x36]
-7f88b81510f3  4883FA11          cmp rdx, +0x11
-7f88b81510f7  741C              jz 0x7f88b8151115
-7f88b81510f9  4881F884000000    cmp rax, 0x84
-7f88b8151100  7413              jz 0x7f88b8151115
-7f88b8151102  4883F82C          cmp rax, +0x2c
-7f88b8151106  753D              jnz 0x7f88b8151145
-7f88b8151108  0FB64736          movzx eax, byte [rdi+0x36]
-7f88b815110c  4881F884000000    cmp rax, 0x84
-7f88b8151113  7530              jnz 0x7f88b8151145
-7f88b8151115  0FB74736          movzx eax, word [rdi+0x36]
-7f88b8151119  66C1C808          ror ax, 0x08
-7f88b815111d  480FB7C0          movzx rax, ax
-7f88b8151121  4881F870170000    cmp rax, 0x1770
-7f88b8151128  7E1E              jle 0x7f88b8151148
-7f88b815112a  4883FE3A          cmp rsi, +0x3a
-7f88b815112e  7C15              jl 0x7f88b8151145
-7f88b8151130  0FB77738          movzx esi, word [rdi+0x38]
-7f88b8151134  66C1CE08          ror si, 0x08
-7f88b8151138  480FB7F6          movzx rsi, si
-7f88b815113c  4881FE70170000    cmp rsi, 0x1770
-7f88b8151143  7E03              jle 0x7f88b8151148
-7f88b8151145  B000              mov al, 0x0
-7f88b8151147  C3                ret
-7f88b8151148  B001              mov al, 0x1
-7f88b815114a  C3                ret
-
+7f438f8d6000  4883FE22          cmp rsi, +0x22
+7f438f8d6004  0F8C3B010000      jl 0x7f438f8d6145
+7f438f8d600a  0FB7470C          movzx eax, word [rdi+0xc]
+7f438f8d600e  4883F808          cmp rax, +0x08
+7f438f8d6012  0F859A000000      jnz 0x7f438f8d60b2
+7f438f8d6018  0FB64F17          movzx ecx, byte [rdi+0x17]
+7f438f8d601c  4883F906          cmp rcx, +0x06
+7f438f8d6020  7413              jz 0x7f438f8d6035
+7f438f8d6022  4883F911          cmp rcx, +0x11
+7f438f8d6026  740D              jz 0x7f438f8d6035
+7f438f8d6028  4881F984000000    cmp rcx, 0x84
+7f438f8d602f  0F8510010000      jnz 0x7f438f8d6145
+7f438f8d6035  0FB74F14          movzx ecx, word [rdi+0x14]
+7f438f8d6039  4881E11FFF0000    and rcx, 0xff1f
+7f438f8d6040  4883F900          cmp rcx, +0x00
+7f438f8d6044  0F85FB000000      jnz 0x7f438f8d6145
+7f438f8d604a  0FB64F0E          movzx ecx, byte [rdi+0xe]
+7f438f8d604e  4883E10F          and rcx, +0x0f
+7f438f8d6052  48C1E102          shl rcx, 0x02
+7f438f8d6056  89CA              mov edx, ecx
+7f438f8d6058  4883C210          add rdx, +0x10
+7f438f8d605c  4839F2            cmp rdx, rsi
+7f438f8d605f  0F8FE0000000      jg 0x7f438f8d6145
+7f438f8d6065  4189C8            mov r8d, ecx
+7f438f8d6068  4983C00E          add r8, +0x0e
+7f438f8d606c  460FB70407        movzx r8d, word [rdi+r8]
+7f438f8d6071  6641C1C808        ror r8w, 0x08
+7f438f8d6076  4D0FB7C0          movzx r8, r8w
+7f438f8d607a  4981F870170000    cmp r8, 0x1770
+7f438f8d6081  0F8EC1000000      jle 0x7f438f8d6148
+7f438f8d6087  4883C112          add rcx, +0x12
+7f438f8d608b  4839F1            cmp rcx, rsi
+7f438f8d608e  0F8FB1000000      jg 0x7f438f8d6145
+7f438f8d6094  0FB71417          movzx edx, word [rdi+rdx]
+7f438f8d6098  66C1CA08          ror dx, 0x08
+7f438f8d609c  480FB7D2          movzx rdx, dx
+7f438f8d60a0  4881FA70170000    cmp rdx, 0x1770
+7f438f8d60a7  0F8E9B000000      jle 0x7f438f8d6148
+7f438f8d60ad  E993000000        jmp 0x7f438f8d6145
+7f438f8d60b2  4883FE38          cmp rsi, +0x38
+7f438f8d60b6  0F8C89000000      jl 0x7f438f8d6145
+7f438f8d60bc  4881F886DD0000    cmp rax, 0xdd86
+7f438f8d60c3  0F857C000000      jnz 0x7f438f8d6145
+7f438f8d60c9  0FB64714          movzx eax, byte [rdi+0x14]
+7f438f8d60cd  4883F806          cmp rax, +0x06
+7f438f8d60d1  7442              jz 0x7f438f8d6115
+7f438f8d60d3  4883F82C          cmp rax, +0x2c
+7f438f8d60d7  750A              jnz 0x7f438f8d60e3
+7f438f8d60d9  0FB65736          movzx edx, byte [rdi+0x36]
+7f438f8d60dd  4883FA06          cmp rdx, +0x06
+7f438f8d60e1  7432              jz 0x7f438f8d6115
+7f438f8d60e3  4883F811          cmp rax, +0x11
+7f438f8d60e7  742C              jz 0x7f438f8d6115
+7f438f8d60e9  4883F82C          cmp rax, +0x2c
+7f438f8d60ed  750A              jnz 0x7f438f8d60f9
+7f438f8d60ef  0FB65736          movzx edx, byte [rdi+0x36]
+7f438f8d60f3  4883FA11          cmp rdx, +0x11
+7f438f8d60f7  741C              jz 0x7f438f8d6115
+7f438f8d60f9  4881F884000000    cmp rax, 0x84
+7f438f8d6100  7413              jz 0x7f438f8d6115
+7f438f8d6102  4883F82C          cmp rax, +0x2c
+7f438f8d6106  753D              jnz 0x7f438f8d6145
+7f438f8d6108  0FB64736          movzx eax, byte [rdi+0x36]
+7f438f8d610c  4881F884000000    cmp rax, 0x84
+7f438f8d6113  7530              jnz 0x7f438f8d6145
+7f438f8d6115  0FB74736          movzx eax, word [rdi+0x36]
+7f438f8d6119  66C1C808          ror ax, 0x08
+7f438f8d611d  480FB7C0          movzx rax, ax
+7f438f8d6121  4881F870170000    cmp rax, 0x1770
+7f438f8d6128  7E1E              jle 0x7f438f8d6148
+7f438f8d612a  4883FE3A          cmp rsi, +0x3a
+7f438f8d612e  7C15              jl 0x7f438f8d6145
+7f438f8d6130  0FB77738          movzx esi, word [rdi+0x38]
+7f438f8d6134  66C1CE08          ror si, 0x08
+7f438f8d6138  480FB7F6          movzx rsi, si
+7f438f8d613c  4881FE70170000    cmp rsi, 0x1770
+7f438f8d6143  7E03              jle 0x7f438f8d6148
+7f438f8d6145  B000              mov al, 0x0
+7f438f8d6147  C3                ret
+7f438f8d6148  B001              mov al, 0x1
+7f438f8d614a  C3                ret
 ```
 

--- a/doc/proto-47.md
+++ b/doc/proto-47.md
@@ -70,38 +70,36 @@ return function(P,length)
    if v2 ~= 44 then return false end
    return P[54] == 47
 end
-
 ```
 
 ## Native pflang compilation
 
 ```
-7fde5d687000  4883FE22          cmp rsi, +0x22
-7fde5d687004  7C43              jl 0x7fde5d687049
-7fde5d687006  0FB7470C          movzx eax, word [rdi+0xc]
-7fde5d68700a  4883F808          cmp rax, +0x08
-7fde5d68700e  750A              jnz 0x7fde5d68701a
-7fde5d687010  0FB64F17          movzx ecx, byte [rdi+0x17]
-7fde5d687014  4883F92F          cmp rcx, +0x2f
-7fde5d687018  7432              jz 0x7fde5d68704c
-7fde5d68701a  4883FE36          cmp rsi, +0x36
-7fde5d68701e  7C29              jl 0x7fde5d687049
-7fde5d687020  4881F886DD0000    cmp rax, 0xdd86
-7fde5d687027  7520              jnz 0x7fde5d687049
-7fde5d687029  0FB64714          movzx eax, byte [rdi+0x14]
-7fde5d68702d  4883F82F          cmp rax, +0x2f
-7fde5d687031  7419              jz 0x7fde5d68704c
-7fde5d687033  4883FE37          cmp rsi, +0x37
-7fde5d687037  7C10              jl 0x7fde5d687049
-7fde5d687039  4883F82C          cmp rax, +0x2c
-7fde5d68703d  750A              jnz 0x7fde5d687049
-7fde5d68703f  0FB64736          movzx eax, byte [rdi+0x36]
-7fde5d687043  4883F82F          cmp rax, +0x2f
-7fde5d687047  7403              jz 0x7fde5d68704c
-7fde5d687049  B000              mov al, 0x0
-7fde5d68704b  C3                ret
-7fde5d68704c  B001              mov al, 0x1
-7fde5d68704e  C3                ret
-
+7f8f726e2000  4883FE22          cmp rsi, +0x22
+7f8f726e2004  7C43              jl 0x7f8f726e2049
+7f8f726e2006  0FB7470C          movzx eax, word [rdi+0xc]
+7f8f726e200a  4883F808          cmp rax, +0x08
+7f8f726e200e  750A              jnz 0x7f8f726e201a
+7f8f726e2010  0FB64F17          movzx ecx, byte [rdi+0x17]
+7f8f726e2014  4883F92F          cmp rcx, +0x2f
+7f8f726e2018  7432              jz 0x7f8f726e204c
+7f8f726e201a  4883FE36          cmp rsi, +0x36
+7f8f726e201e  7C29              jl 0x7f8f726e2049
+7f8f726e2020  4881F886DD0000    cmp rax, 0xdd86
+7f8f726e2027  7520              jnz 0x7f8f726e2049
+7f8f726e2029  0FB64714          movzx eax, byte [rdi+0x14]
+7f8f726e202d  4883F82F          cmp rax, +0x2f
+7f8f726e2031  7419              jz 0x7f8f726e204c
+7f8f726e2033  4883FE37          cmp rsi, +0x37
+7f8f726e2037  7C10              jl 0x7f8f726e2049
+7f8f726e2039  4883F82C          cmp rax, +0x2c
+7f8f726e203d  750A              jnz 0x7f8f726e2049
+7f8f726e203f  0FB64736          movzx eax, byte [rdi+0x36]
+7f8f726e2043  4883F82F          cmp rax, +0x2f
+7f8f726e2047  7403              jz 0x7f8f726e204c
+7f8f726e2049  B000              mov al, 0x0
+7f8f726e204b  C3                ret
+7f8f726e204c  B001              mov al, 0x1
+7f8f726e204e  C3                ret
 ```
 

--- a/doc/proto-sctp.md
+++ b/doc/proto-sctp.md
@@ -70,38 +70,36 @@ return function(P,length)
    if v2 ~= 44 then return false end
    return P[54] == 132
 end
-
 ```
 
 ## Native pflang compilation
 
 ```
-7fc73f3c2000  4883FE22          cmp rsi, +0x22
-7fc73f3c2004  7C4C              jl 0x7fc73f3c2052
-7fc73f3c2006  0FB7470C          movzx eax, word [rdi+0xc]
-7fc73f3c200a  4883F808          cmp rax, +0x08
-7fc73f3c200e  750D              jnz 0x7fc73f3c201d
-7fc73f3c2010  0FB64F17          movzx ecx, byte [rdi+0x17]
-7fc73f3c2014  4881F984000000    cmp rcx, 0x84
-7fc73f3c201b  7438              jz 0x7fc73f3c2055
-7fc73f3c201d  4883FE36          cmp rsi, +0x36
-7fc73f3c2021  7C2F              jl 0x7fc73f3c2052
-7fc73f3c2023  4881F886DD0000    cmp rax, 0xdd86
-7fc73f3c202a  7526              jnz 0x7fc73f3c2052
-7fc73f3c202c  0FB64714          movzx eax, byte [rdi+0x14]
-7fc73f3c2030  4881F884000000    cmp rax, 0x84
-7fc73f3c2037  741C              jz 0x7fc73f3c2055
-7fc73f3c2039  4883FE37          cmp rsi, +0x37
-7fc73f3c203d  7C13              jl 0x7fc73f3c2052
-7fc73f3c203f  4883F82C          cmp rax, +0x2c
-7fc73f3c2043  750D              jnz 0x7fc73f3c2052
-7fc73f3c2045  0FB64736          movzx eax, byte [rdi+0x36]
-7fc73f3c2049  4881F884000000    cmp rax, 0x84
-7fc73f3c2050  7403              jz 0x7fc73f3c2055
-7fc73f3c2052  B000              mov al, 0x0
-7fc73f3c2054  C3                ret
-7fc73f3c2055  B001              mov al, 0x1
-7fc73f3c2057  C3                ret
-
+7fdeec219000  4883FE22          cmp rsi, +0x22
+7fdeec219004  7C4C              jl 0x7fdeec219052
+7fdeec219006  0FB7470C          movzx eax, word [rdi+0xc]
+7fdeec21900a  4883F808          cmp rax, +0x08
+7fdeec21900e  750D              jnz 0x7fdeec21901d
+7fdeec219010  0FB64F17          movzx ecx, byte [rdi+0x17]
+7fdeec219014  4881F984000000    cmp rcx, 0x84
+7fdeec21901b  7438              jz 0x7fdeec219055
+7fdeec21901d  4883FE36          cmp rsi, +0x36
+7fdeec219021  7C2F              jl 0x7fdeec219052
+7fdeec219023  4881F886DD0000    cmp rax, 0xdd86
+7fdeec21902a  7526              jnz 0x7fdeec219052
+7fdeec21902c  0FB64714          movzx eax, byte [rdi+0x14]
+7fdeec219030  4881F884000000    cmp rax, 0x84
+7fdeec219037  741C              jz 0x7fdeec219055
+7fdeec219039  4883FE37          cmp rsi, +0x37
+7fdeec21903d  7C13              jl 0x7fdeec219052
+7fdeec21903f  4883F82C          cmp rax, +0x2c
+7fdeec219043  750D              jnz 0x7fdeec219052
+7fdeec219045  0FB64736          movzx eax, byte [rdi+0x36]
+7fdeec219049  4881F884000000    cmp rax, 0x84
+7fdeec219050  7403              jz 0x7fdeec219055
+7fdeec219052  B000              mov al, 0x0
+7fdeec219054  C3                ret
+7fdeec219055  B001              mov al, 0x1
+7fdeec219057  C3                ret
 ```
 

--- a/doc/sctp.md
+++ b/doc/sctp.md
@@ -67,39 +67,37 @@ return function(P,length)
    if v2 ~= 44 then return false end
    return P[54] == 132
 end
-
 ```
 
 ## Native pflang compilation
 
 ```
-7eff3cb65000  4883FE22          cmp rsi, +0x22
-7eff3cb65004  7C4E              jl 0x7eff3cb65054
-7eff3cb65006  0FB7470C          movzx eax, word [rdi+0xc]
-7eff3cb6500a  4883F808          cmp rax, +0x08
-7eff3cb6500e  750F              jnz 0x7eff3cb6501f
-7eff3cb65010  0FB64F17          movzx ecx, byte [rdi+0x17]
-7eff3cb65014  4881F984000000    cmp rcx, 0x84
-7eff3cb6501b  743A              jz 0x7eff3cb65057
-7eff3cb6501d  EB35              jmp 0x7eff3cb65054
-7eff3cb6501f  4883FE36          cmp rsi, +0x36
-7eff3cb65023  7C2F              jl 0x7eff3cb65054
-7eff3cb65025  4881F886DD0000    cmp rax, 0xdd86
-7eff3cb6502c  7526              jnz 0x7eff3cb65054
-7eff3cb6502e  0FB64714          movzx eax, byte [rdi+0x14]
-7eff3cb65032  4881F884000000    cmp rax, 0x84
-7eff3cb65039  741C              jz 0x7eff3cb65057
-7eff3cb6503b  4883FE37          cmp rsi, +0x37
-7eff3cb6503f  7C13              jl 0x7eff3cb65054
-7eff3cb65041  4883F82C          cmp rax, +0x2c
-7eff3cb65045  750D              jnz 0x7eff3cb65054
-7eff3cb65047  0FB64736          movzx eax, byte [rdi+0x36]
-7eff3cb6504b  4881F884000000    cmp rax, 0x84
-7eff3cb65052  7403              jz 0x7eff3cb65057
-7eff3cb65054  B000              mov al, 0x0
-7eff3cb65056  C3                ret
-7eff3cb65057  B001              mov al, 0x1
-7eff3cb65059  C3                ret
-
+7f08ad4cb000  4883FE22          cmp rsi, +0x22
+7f08ad4cb004  7C4E              jl 0x7f08ad4cb054
+7f08ad4cb006  0FB7470C          movzx eax, word [rdi+0xc]
+7f08ad4cb00a  4883F808          cmp rax, +0x08
+7f08ad4cb00e  750F              jnz 0x7f08ad4cb01f
+7f08ad4cb010  0FB64F17          movzx ecx, byte [rdi+0x17]
+7f08ad4cb014  4881F984000000    cmp rcx, 0x84
+7f08ad4cb01b  743A              jz 0x7f08ad4cb057
+7f08ad4cb01d  EB35              jmp 0x7f08ad4cb054
+7f08ad4cb01f  4883FE36          cmp rsi, +0x36
+7f08ad4cb023  7C2F              jl 0x7f08ad4cb054
+7f08ad4cb025  4881F886DD0000    cmp rax, 0xdd86
+7f08ad4cb02c  7526              jnz 0x7f08ad4cb054
+7f08ad4cb02e  0FB64714          movzx eax, byte [rdi+0x14]
+7f08ad4cb032  4881F884000000    cmp rax, 0x84
+7f08ad4cb039  741C              jz 0x7f08ad4cb057
+7f08ad4cb03b  4883FE37          cmp rsi, +0x37
+7f08ad4cb03f  7C13              jl 0x7f08ad4cb054
+7f08ad4cb041  4883F82C          cmp rax, +0x2c
+7f08ad4cb045  750D              jnz 0x7f08ad4cb054
+7f08ad4cb047  0FB64736          movzx eax, byte [rdi+0x36]
+7f08ad4cb04b  4881F884000000    cmp rax, 0x84
+7f08ad4cb052  7403              jz 0x7f08ad4cb057
+7f08ad4cb054  B000              mov al, 0x0
+7f08ad4cb056  C3                ret
+7f08ad4cb057  B001              mov al, 0x1
+7f08ad4cb059  C3                ret
 ```
 

--- a/doc/src-host-192.68.1.1-and-less-100.md
+++ b/doc/src-host-192.68.1.1-and-less-100.md
@@ -77,36 +77,34 @@ return function(P,length)
 ::L7::
    return false
 end
-
 ```
 
 ## Native pflang compilation
 
 ```
-7faa9eb0a000  4883FE22          cmp rsi, +0x22
-7faa9eb0a004  7C42              jl 0x7faa9eb0a048
-7faa9eb0a006  0FB7470C          movzx eax, word [rdi+0xc]
-7faa9eb0a00a  4883F808          cmp rax, +0x08
-7faa9eb0a00e  750E              jnz 0x7faa9eb0a01e
-7faa9eb0a010  8B4F1A            mov ecx, [rdi+0x1a]
-7faa9eb0a013  4881F9C0440101    cmp rcx, 0x010144c0
-7faa9eb0a01a  7426              jz 0x7faa9eb0a042
-7faa9eb0a01c  EB2A              jmp 0x7faa9eb0a048
-7faa9eb0a01e  4883FE2A          cmp rsi, +0x2a
-7faa9eb0a022  7C24              jl 0x7faa9eb0a048
-7faa9eb0a024  4881F808060000    cmp rax, 0x608
-7faa9eb0a02b  7409              jz 0x7faa9eb0a036
-7faa9eb0a02d  4881F880350000    cmp rax, 0x3580
-7faa9eb0a034  7512              jnz 0x7faa9eb0a048
-7faa9eb0a036  8B471C            mov eax, [rdi+0x1c]
-7faa9eb0a039  4881F8C0440101    cmp rax, 0x010144c0
-7faa9eb0a040  7506              jnz 0x7faa9eb0a048
-7faa9eb0a042  4883FE64          cmp rsi, +0x64
-7faa9eb0a046  7E03              jle 0x7faa9eb0a04b
-7faa9eb0a048  B000              mov al, 0x0
-7faa9eb0a04a  C3                ret
-7faa9eb0a04b  B001              mov al, 0x1
-7faa9eb0a04d  C3                ret
-
+7f09d5ee8000  4883FE22          cmp rsi, +0x22
+7f09d5ee8004  7C42              jl 0x7f09d5ee8048
+7f09d5ee8006  0FB7470C          movzx eax, word [rdi+0xc]
+7f09d5ee800a  4883F808          cmp rax, +0x08
+7f09d5ee800e  750E              jnz 0x7f09d5ee801e
+7f09d5ee8010  8B4F1A            mov ecx, [rdi+0x1a]
+7f09d5ee8013  4881F9C0440101    cmp rcx, 0x010144c0
+7f09d5ee801a  7426              jz 0x7f09d5ee8042
+7f09d5ee801c  EB2A              jmp 0x7f09d5ee8048
+7f09d5ee801e  4883FE2A          cmp rsi, +0x2a
+7f09d5ee8022  7C24              jl 0x7f09d5ee8048
+7f09d5ee8024  4881F808060000    cmp rax, 0x608
+7f09d5ee802b  7409              jz 0x7f09d5ee8036
+7f09d5ee802d  4881F880350000    cmp rax, 0x3580
+7f09d5ee8034  7512              jnz 0x7f09d5ee8048
+7f09d5ee8036  8B471C            mov eax, [rdi+0x1c]
+7f09d5ee8039  4881F8C0440101    cmp rax, 0x010144c0
+7f09d5ee8040  7506              jnz 0x7f09d5ee8048
+7f09d5ee8042  4883FE64          cmp rsi, +0x64
+7f09d5ee8046  7E03              jle 0x7f09d5ee804b
+7f09d5ee8048  B000              mov al, 0x0
+7f09d5ee804a  C3                ret
+7f09d5ee804b  B001              mov al, 0x1
+7f09d5ee804d  C3                ret
 ```
 

--- a/doc/src-net-ffff.ffff.eeee.eeee.0.0.0.0-72.md
+++ b/doc/src-net-ffff.ffff.eeee.eeee.0.0.0.0-72.md
@@ -54,33 +54,31 @@ return function(P,length)
    if cast("uint32_t*", P+26)[0] ~= 4008636142 then return false end
    return band(cast("uint32_t*", P+30)[0],255) == 0
 end
-
 ```
 
 ## Native pflang compilation
 
 ```
-7f28f2b29000  4883FE36          cmp rsi, +0x36
-7f28f2b29004  7C41              jl 0x7f28f2b29047
-7f28f2b29006  0FB7770C          movzx esi, word [rdi+0xc]
-7f28f2b2900a  4881FE86DD0000    cmp rsi, 0xdd86
-7f28f2b29011  7534              jnz 0x7f28f2b29047
-7f28f2b29013  8B7716            mov esi, [rdi+0x16]
-7f28f2b29016  48B8FFFFFFFF0000. mov rax, 0x00000000ffffffff
-7f28f2b29020  4839C6            cmp rsi, rax
-7f28f2b29023  7522              jnz 0x7f28f2b29047
-7f28f2b29025  8B471A            mov eax, [rdi+0x1a]
-7f28f2b29028  48BEEEEEEEEE0000. mov rsi, 0x00000000eeeeeeee
-7f28f2b29032  4839F0            cmp rax, rsi
-7f28f2b29035  7510              jnz 0x7f28f2b29047
-7f28f2b29037  8B771E            mov esi, [rdi+0x1e]
-7f28f2b2903a  4881E6FF000000    and rsi, 0xff
-7f28f2b29041  4883FE00          cmp rsi, +0x00
-7f28f2b29045  7403              jz 0x7f28f2b2904a
-7f28f2b29047  B000              mov al, 0x0
-7f28f2b29049  C3                ret
-7f28f2b2904a  B001              mov al, 0x1
-7f28f2b2904c  C3                ret
-
+7f3702ce8000  4883FE36          cmp rsi, +0x36
+7f3702ce8004  7C41              jl 0x7f3702ce8047
+7f3702ce8006  0FB7770C          movzx esi, word [rdi+0xc]
+7f3702ce800a  4881FE86DD0000    cmp rsi, 0xdd86
+7f3702ce8011  7534              jnz 0x7f3702ce8047
+7f3702ce8013  8B7716            mov esi, [rdi+0x16]
+7f3702ce8016  48B8FFFFFFFF0000. mov rax, 0x00000000ffffffff
+7f3702ce8020  4839C6            cmp rsi, rax
+7f3702ce8023  7522              jnz 0x7f3702ce8047
+7f3702ce8025  8B471A            mov eax, [rdi+0x1a]
+7f3702ce8028  48BEEEEEEEEE0000. mov rsi, 0x00000000eeeeeeee
+7f3702ce8032  4839F0            cmp rax, rsi
+7f3702ce8035  7510              jnz 0x7f3702ce8047
+7f3702ce8037  8B771E            mov esi, [rdi+0x1e]
+7f3702ce803a  4881E6FF000000    and rsi, 0xff
+7f3702ce8041  4883FE00          cmp rsi, +0x00
+7f3702ce8045  7403              jz 0x7f3702ce804a
+7f3702ce8047  B000              mov al, 0x0
+7f3702ce8049  C3                ret
+7f3702ce804a  B001              mov al, 0x1
+7f3702ce804c  C3                ret
 ```
 

--- a/doc/src-net-ffff.ffff.eeee.eeee.1.0.0.0-82.md
+++ b/doc/src-net-ffff.ffff.eeee.eeee.1.0.0.0-82.md
@@ -56,33 +56,31 @@ return function(P,length)
    if cast("uint32_t*", P+26)[0] ~= 4008636142 then return false end
    return band(cast("uint32_t*", P+30)[0],12648447) == 256
 end
-
 ```
 
 ## Native pflang compilation
 
 ```
-7f772e248000  4883FE36          cmp rsi, +0x36
-7f772e248004  7C44              jl 0x7f772e24804a
-7f772e248006  0FB7770C          movzx esi, word [rdi+0xc]
-7f772e24800a  4881FE86DD0000    cmp rsi, 0xdd86
-7f772e248011  7537              jnz 0x7f772e24804a
-7f772e248013  8B7716            mov esi, [rdi+0x16]
-7f772e248016  48B8FFFFFFFF0000. mov rax, 0x00000000ffffffff
-7f772e248020  4839C6            cmp rsi, rax
-7f772e248023  7525              jnz 0x7f772e24804a
-7f772e248025  8B471A            mov eax, [rdi+0x1a]
-7f772e248028  48BEEEEEEEEE0000. mov rsi, 0x00000000eeeeeeee
-7f772e248032  4839F0            cmp rax, rsi
-7f772e248035  7513              jnz 0x7f772e24804a
-7f772e248037  8B771E            mov esi, [rdi+0x1e]
-7f772e24803a  4881E6FFFFC000    and rsi, 0x00c0ffff
-7f772e248041  4881FE00010000    cmp rsi, 0x100
-7f772e248048  7403              jz 0x7f772e24804d
-7f772e24804a  B000              mov al, 0x0
-7f772e24804c  C3                ret
-7f772e24804d  B001              mov al, 0x1
-7f772e24804f  C3                ret
-
+7ff0ac218000  4883FE36          cmp rsi, +0x36
+7ff0ac218004  7C44              jl 0x7ff0ac21804a
+7ff0ac218006  0FB7770C          movzx esi, word [rdi+0xc]
+7ff0ac21800a  4881FE86DD0000    cmp rsi, 0xdd86
+7ff0ac218011  7537              jnz 0x7ff0ac21804a
+7ff0ac218013  8B7716            mov esi, [rdi+0x16]
+7ff0ac218016  48B8FFFFFFFF0000. mov rax, 0x00000000ffffffff
+7ff0ac218020  4839C6            cmp rsi, rax
+7ff0ac218023  7525              jnz 0x7ff0ac21804a
+7ff0ac218025  8B471A            mov eax, [rdi+0x1a]
+7ff0ac218028  48BEEEEEEEEE0000. mov rsi, 0x00000000eeeeeeee
+7ff0ac218032  4839F0            cmp rax, rsi
+7ff0ac218035  7513              jnz 0x7ff0ac21804a
+7ff0ac218037  8B771E            mov esi, [rdi+0x1e]
+7ff0ac21803a  4881E6FFFFC000    and rsi, 0x00c0ffff
+7ff0ac218041  4881FE00010000    cmp rsi, 0x100
+7ff0ac218048  7403              jz 0x7ff0ac21804d
+7ff0ac21804a  B000              mov al, 0x0
+7ff0ac21804c  C3                ret
+7ff0ac21804d  B001              mov al, 0x1
+7ff0ac21804f  C3                ret
 ```
 

--- a/doc/src-port-80.md
+++ b/doc/src-port-80.md
@@ -123,73 +123,71 @@ return function(P,length)
       return cast("uint16_t*", P+54)[0] == 20480
    end
 end
-
 ```
 
 ## Native pflang compilation
 
 ```
-7f82c3d63000  4883FE22          cmp rsi, +0x22
-7f82c3d63004  0F8CE1000000      jl 0x7f82c3d630eb
-7f82c3d6300a  0FB7470C          movzx eax, word [rdi+0xc]
-7f82c3d6300e  4883F808          cmp rax, +0x08
-7f82c3d63012  7567              jnz 0x7f82c3d6307b
-7f82c3d63014  0FB64F17          movzx ecx, byte [rdi+0x17]
-7f82c3d63018  4883F906          cmp rcx, +0x06
-7f82c3d6301c  7413              jz 0x7f82c3d63031
-7f82c3d6301e  4883F911          cmp rcx, +0x11
-7f82c3d63022  740D              jz 0x7f82c3d63031
-7f82c3d63024  4881F984000000    cmp rcx, 0x84
-7f82c3d6302b  0F85BA000000      jnz 0x7f82c3d630eb
-7f82c3d63031  0FB74F14          movzx ecx, word [rdi+0x14]
-7f82c3d63035  4881E11FFF0000    and rcx, 0xff1f
-7f82c3d6303c  4883F900          cmp rcx, +0x00
-7f82c3d63040  0F85A5000000      jnz 0x7f82c3d630eb
-7f82c3d63046  0FB64F0E          movzx ecx, byte [rdi+0xe]
-7f82c3d6304a  4883E10F          and rcx, +0x0f
-7f82c3d6304e  48C1E102          shl rcx, 0x02
-7f82c3d63052  89CA              mov edx, ecx
-7f82c3d63054  4883C210          add rdx, +0x10
-7f82c3d63058  4839F2            cmp rdx, rsi
-7f82c3d6305b  0F8F8A000000      jg 0x7f82c3d630eb
-7f82c3d63061  4883C10E          add rcx, +0x0e
-7f82c3d63065  0FB70C0F          movzx ecx, word [rdi+rcx]
-7f82c3d63069  4881F900500000    cmp rcx, 0x5000
-7f82c3d63070  0F8478000000      jz 0x7f82c3d630ee
-7f82c3d63076  E970000000        jmp 0x7f82c3d630eb
-7f82c3d6307b  4883FE38          cmp rsi, +0x38
-7f82c3d6307f  0F8C66000000      jl 0x7f82c3d630eb
-7f82c3d63085  4881F886DD0000    cmp rax, 0xdd86
-7f82c3d6308c  0F8559000000      jnz 0x7f82c3d630eb
-7f82c3d63092  0FB64714          movzx eax, byte [rdi+0x14]
-7f82c3d63096  4883F806          cmp rax, +0x06
-7f82c3d6309a  7442              jz 0x7f82c3d630de
-7f82c3d6309c  4883F82C          cmp rax, +0x2c
-7f82c3d630a0  750A              jnz 0x7f82c3d630ac
-7f82c3d630a2  0FB67736          movzx esi, byte [rdi+0x36]
-7f82c3d630a6  4883FE06          cmp rsi, +0x06
-7f82c3d630aa  7432              jz 0x7f82c3d630de
-7f82c3d630ac  4883F811          cmp rax, +0x11
-7f82c3d630b0  742C              jz 0x7f82c3d630de
-7f82c3d630b2  4883F82C          cmp rax, +0x2c
-7f82c3d630b6  750A              jnz 0x7f82c3d630c2
-7f82c3d630b8  0FB67736          movzx esi, byte [rdi+0x36]
-7f82c3d630bc  4883FE11          cmp rsi, +0x11
-7f82c3d630c0  741C              jz 0x7f82c3d630de
-7f82c3d630c2  4881F884000000    cmp rax, 0x84
-7f82c3d630c9  7413              jz 0x7f82c3d630de
-7f82c3d630cb  4883F82C          cmp rax, +0x2c
-7f82c3d630cf  751A              jnz 0x7f82c3d630eb
-7f82c3d630d1  0FB64736          movzx eax, byte [rdi+0x36]
-7f82c3d630d5  4881F884000000    cmp rax, 0x84
-7f82c3d630dc  750D              jnz 0x7f82c3d630eb
-7f82c3d630de  0FB74736          movzx eax, word [rdi+0x36]
-7f82c3d630e2  4881F800500000    cmp rax, 0x5000
-7f82c3d630e9  7403              jz 0x7f82c3d630ee
-7f82c3d630eb  B000              mov al, 0x0
-7f82c3d630ed  C3                ret
-7f82c3d630ee  B001              mov al, 0x1
-7f82c3d630f0  C3                ret
-
+7fa79148f000  4883FE22          cmp rsi, +0x22
+7fa79148f004  0F8CE1000000      jl 0x7fa79148f0eb
+7fa79148f00a  0FB7470C          movzx eax, word [rdi+0xc]
+7fa79148f00e  4883F808          cmp rax, +0x08
+7fa79148f012  7567              jnz 0x7fa79148f07b
+7fa79148f014  0FB64F17          movzx ecx, byte [rdi+0x17]
+7fa79148f018  4883F906          cmp rcx, +0x06
+7fa79148f01c  7413              jz 0x7fa79148f031
+7fa79148f01e  4883F911          cmp rcx, +0x11
+7fa79148f022  740D              jz 0x7fa79148f031
+7fa79148f024  4881F984000000    cmp rcx, 0x84
+7fa79148f02b  0F85BA000000      jnz 0x7fa79148f0eb
+7fa79148f031  0FB74F14          movzx ecx, word [rdi+0x14]
+7fa79148f035  4881E11FFF0000    and rcx, 0xff1f
+7fa79148f03c  4883F900          cmp rcx, +0x00
+7fa79148f040  0F85A5000000      jnz 0x7fa79148f0eb
+7fa79148f046  0FB64F0E          movzx ecx, byte [rdi+0xe]
+7fa79148f04a  4883E10F          and rcx, +0x0f
+7fa79148f04e  48C1E102          shl rcx, 0x02
+7fa79148f052  89CA              mov edx, ecx
+7fa79148f054  4883C210          add rdx, +0x10
+7fa79148f058  4839F2            cmp rdx, rsi
+7fa79148f05b  0F8F8A000000      jg 0x7fa79148f0eb
+7fa79148f061  4883C10E          add rcx, +0x0e
+7fa79148f065  0FB70C0F          movzx ecx, word [rdi+rcx]
+7fa79148f069  4881F900500000    cmp rcx, 0x5000
+7fa79148f070  0F8478000000      jz 0x7fa79148f0ee
+7fa79148f076  E970000000        jmp 0x7fa79148f0eb
+7fa79148f07b  4883FE38          cmp rsi, +0x38
+7fa79148f07f  0F8C66000000      jl 0x7fa79148f0eb
+7fa79148f085  4881F886DD0000    cmp rax, 0xdd86
+7fa79148f08c  0F8559000000      jnz 0x7fa79148f0eb
+7fa79148f092  0FB64714          movzx eax, byte [rdi+0x14]
+7fa79148f096  4883F806          cmp rax, +0x06
+7fa79148f09a  7442              jz 0x7fa79148f0de
+7fa79148f09c  4883F82C          cmp rax, +0x2c
+7fa79148f0a0  750A              jnz 0x7fa79148f0ac
+7fa79148f0a2  0FB67736          movzx esi, byte [rdi+0x36]
+7fa79148f0a6  4883FE06          cmp rsi, +0x06
+7fa79148f0aa  7432              jz 0x7fa79148f0de
+7fa79148f0ac  4883F811          cmp rax, +0x11
+7fa79148f0b0  742C              jz 0x7fa79148f0de
+7fa79148f0b2  4883F82C          cmp rax, +0x2c
+7fa79148f0b6  750A              jnz 0x7fa79148f0c2
+7fa79148f0b8  0FB67736          movzx esi, byte [rdi+0x36]
+7fa79148f0bc  4883FE11          cmp rsi, +0x11
+7fa79148f0c0  741C              jz 0x7fa79148f0de
+7fa79148f0c2  4881F884000000    cmp rax, 0x84
+7fa79148f0c9  7413              jz 0x7fa79148f0de
+7fa79148f0cb  4883F82C          cmp rax, +0x2c
+7fa79148f0cf  751A              jnz 0x7fa79148f0eb
+7fa79148f0d1  0FB64736          movzx eax, byte [rdi+0x36]
+7fa79148f0d5  4881F884000000    cmp rax, 0x84
+7fa79148f0dc  750D              jnz 0x7fa79148f0eb
+7fa79148f0de  0FB74736          movzx eax, word [rdi+0x36]
+7fa79148f0e2  4881F800500000    cmp rax, 0x5000
+7fa79148f0e9  7403              jz 0x7fa79148f0ee
+7fa79148f0eb  B000              mov al, 0x0
+7fa79148f0ed  C3                ret
+7fa79148f0ee  B001              mov al, 0x1
+7fa79148f0f0  C3                ret
 ```
 

--- a/doc/tcp-address.md
+++ b/doc/tcp-address.md
@@ -4,7 +4,8 @@
 ## BPF
 
 ```
-Filter failed to compile: ../src/pf/libpcap.lua:66: pcap_compile failed```
+Filter failed to compile: ../src/pf/libpcap.lua:66: pcap_compile failed
+```
 
 
 ## BPF cross-compiled to Lua
@@ -30,39 +31,37 @@ return function(P,length)
    local v2 = P[(v1 + 14)]
    return v2 == v2
 end
-
 ```
 
 ## Native pflang compilation
 
 ```
-7f342d178000  4883FE36          cmp rsi, +0x36
-7f342d178004  7C49              jl 0x7f342d17804f
-7f342d178006  0FB7470C          movzx eax, word [rdi+0xc]
-7f342d17800a  4883F808          cmp rax, +0x08
-7f342d17800e  753F              jnz 0x7f342d17804f
-7f342d178010  0FB64717          movzx eax, byte [rdi+0x17]
-7f342d178014  4883F806          cmp rax, +0x06
-7f342d178018  7535              jnz 0x7f342d17804f
-7f342d17801a  0FB74714          movzx eax, word [rdi+0x14]
-7f342d17801e  4881E01FFF0000    and rax, 0xff1f
-7f342d178025  4883F800          cmp rax, +0x00
-7f342d178029  7524              jnz 0x7f342d17804f
-7f342d17802b  0FB6470E          movzx eax, byte [rdi+0xe]
-7f342d17802f  4883E00F          and rax, +0x0f
-7f342d178033  48C1E002          shl rax, 0x02
-7f342d178037  89C1              mov ecx, eax
-7f342d178039  4883C10F          add rcx, +0x0f
-7f342d17803d  4839F1            cmp rcx, rsi
-7f342d178040  7F0D              jg 0x7f342d17804f
-7f342d178042  4883C00E          add rax, +0x0e
-7f342d178046  0FB60407          movzx eax, byte [rdi+rax]
-7f342d17804a  4839C0            cmp rax, rax
-7f342d17804d  7403              jz 0x7f342d178052
-7f342d17804f  B000              mov al, 0x0
-7f342d178051  C3                ret
-7f342d178052  B001              mov al, 0x1
-7f342d178054  C3                ret
-
+7f1405509000  4883FE36          cmp rsi, +0x36
+7f1405509004  7C49              jl 0x7f140550904f
+7f1405509006  0FB7470C          movzx eax, word [rdi+0xc]
+7f140550900a  4883F808          cmp rax, +0x08
+7f140550900e  753F              jnz 0x7f140550904f
+7f1405509010  0FB64717          movzx eax, byte [rdi+0x17]
+7f1405509014  4883F806          cmp rax, +0x06
+7f1405509018  7535              jnz 0x7f140550904f
+7f140550901a  0FB74714          movzx eax, word [rdi+0x14]
+7f140550901e  4881E01FFF0000    and rax, 0xff1f
+7f1405509025  4883F800          cmp rax, +0x00
+7f1405509029  7524              jnz 0x7f140550904f
+7f140550902b  0FB6470E          movzx eax, byte [rdi+0xe]
+7f140550902f  4883E00F          and rax, +0x0f
+7f1405509033  48C1E002          shl rax, 0x02
+7f1405509037  89C1              mov ecx, eax
+7f1405509039  4883C10F          add rcx, +0x0f
+7f140550903d  4839F1            cmp rcx, rsi
+7f1405509040  7F0D              jg 0x7f140550904f
+7f1405509042  4883C00E          add rax, +0x0e
+7f1405509046  0FB60407          movzx eax, byte [rdi+rax]
+7f140550904a  4839C0            cmp rax, rax
+7f140550904d  7403              jz 0x7f1405509052
+7f140550904f  B000              mov al, 0x0
+7f1405509051  C3                ret
+7f1405509052  B001              mov al, 0x1
+7f1405509054  C3                ret
 ```
 

--- a/doc/tcp-port-80.md
+++ b/doc/tcp-port-80.md
@@ -108,67 +108,65 @@ return function(P,length)
       return cast("uint16_t*", P+56)[0] == 20480
    end
 end
-
 ```
 
 ## Native pflang compilation
 
 ```
-7fbe86845000  4883FE22          cmp rsi, +0x22
-7fbe86845004  0F8CC2000000      jl 0x7fbe868450cc
-7fbe8684500a  0FB7470C          movzx eax, word [rdi+0xc]
-7fbe8684500e  4883F808          cmp rax, +0x08
-7fbe86845012  756F              jnz 0x7fbe86845083
-7fbe86845014  0FB64F17          movzx ecx, byte [rdi+0x17]
-7fbe86845018  4883F906          cmp rcx, +0x06
-7fbe8684501c  0F85AA000000      jnz 0x7fbe868450cc
-7fbe86845022  0FB74F14          movzx ecx, word [rdi+0x14]
-7fbe86845026  4881E11FFF0000    and rcx, 0xff1f
-7fbe8684502d  4883F900          cmp rcx, +0x00
-7fbe86845031  0F8595000000      jnz 0x7fbe868450cc
-7fbe86845037  0FB64F0E          movzx ecx, byte [rdi+0xe]
-7fbe8684503b  4883E10F          and rcx, +0x0f
-7fbe8684503f  48C1E102          shl rcx, 0x02
-7fbe86845043  89CA              mov edx, ecx
-7fbe86845045  4883C210          add rdx, +0x10
-7fbe86845049  4839F2            cmp rdx, rsi
-7fbe8684504c  0F8F7A000000      jg 0x7fbe868450cc
-7fbe86845052  4189C8            mov r8d, ecx
-7fbe86845055  4983C00E          add r8, +0x0e
-7fbe86845059  460FB70407        movzx r8d, word [rdi+r8]
-7fbe8684505e  4981F800500000    cmp r8, 0x5000
-7fbe86845065  0F8464000000      jz 0x7fbe868450cf
-7fbe8684506b  4883C112          add rcx, +0x12
-7fbe8684506f  4839F1            cmp rcx, rsi
-7fbe86845072  7F58              jg 0x7fbe868450cc
-7fbe86845074  0FB71417          movzx edx, word [rdi+rdx]
-7fbe86845078  4881FA00500000    cmp rdx, 0x5000
-7fbe8684507f  744E              jz 0x7fbe868450cf
-7fbe86845081  EB49              jmp 0x7fbe868450cc
-7fbe86845083  4883FE38          cmp rsi, +0x38
-7fbe86845087  7C43              jl 0x7fbe868450cc
-7fbe86845089  4881F886DD0000    cmp rax, 0xdd86
-7fbe86845090  753A              jnz 0x7fbe868450cc
-7fbe86845092  0FB64714          movzx eax, byte [rdi+0x14]
-7fbe86845096  4883F806          cmp rax, +0x06
-7fbe8684509a  7410              jz 0x7fbe868450ac
-7fbe8684509c  4883F82C          cmp rax, +0x2c
-7fbe868450a0  752A              jnz 0x7fbe868450cc
-7fbe868450a2  0FB64736          movzx eax, byte [rdi+0x36]
-7fbe868450a6  4883F806          cmp rax, +0x06
-7fbe868450aa  7520              jnz 0x7fbe868450cc
-7fbe868450ac  0FB74736          movzx eax, word [rdi+0x36]
-7fbe868450b0  4881F800500000    cmp rax, 0x5000
-7fbe868450b7  7416              jz 0x7fbe868450cf
-7fbe868450b9  4883FE3A          cmp rsi, +0x3a
-7fbe868450bd  7C0D              jl 0x7fbe868450cc
-7fbe868450bf  0FB77738          movzx esi, word [rdi+0x38]
-7fbe868450c3  4881FE00500000    cmp rsi, 0x5000
-7fbe868450ca  7403              jz 0x7fbe868450cf
-7fbe868450cc  B000              mov al, 0x0
-7fbe868450ce  C3                ret
-7fbe868450cf  B001              mov al, 0x1
-7fbe868450d1  C3                ret
-
+7f5ecada9000  4883FE22          cmp rsi, +0x22
+7f5ecada9004  0F8CC2000000      jl 0x7f5ecada90cc
+7f5ecada900a  0FB7470C          movzx eax, word [rdi+0xc]
+7f5ecada900e  4883F808          cmp rax, +0x08
+7f5ecada9012  756F              jnz 0x7f5ecada9083
+7f5ecada9014  0FB64F17          movzx ecx, byte [rdi+0x17]
+7f5ecada9018  4883F906          cmp rcx, +0x06
+7f5ecada901c  0F85AA000000      jnz 0x7f5ecada90cc
+7f5ecada9022  0FB74F14          movzx ecx, word [rdi+0x14]
+7f5ecada9026  4881E11FFF0000    and rcx, 0xff1f
+7f5ecada902d  4883F900          cmp rcx, +0x00
+7f5ecada9031  0F8595000000      jnz 0x7f5ecada90cc
+7f5ecada9037  0FB64F0E          movzx ecx, byte [rdi+0xe]
+7f5ecada903b  4883E10F          and rcx, +0x0f
+7f5ecada903f  48C1E102          shl rcx, 0x02
+7f5ecada9043  89CA              mov edx, ecx
+7f5ecada9045  4883C210          add rdx, +0x10
+7f5ecada9049  4839F2            cmp rdx, rsi
+7f5ecada904c  0F8F7A000000      jg 0x7f5ecada90cc
+7f5ecada9052  4189C8            mov r8d, ecx
+7f5ecada9055  4983C00E          add r8, +0x0e
+7f5ecada9059  460FB70407        movzx r8d, word [rdi+r8]
+7f5ecada905e  4981F800500000    cmp r8, 0x5000
+7f5ecada9065  0F8464000000      jz 0x7f5ecada90cf
+7f5ecada906b  4883C112          add rcx, +0x12
+7f5ecada906f  4839F1            cmp rcx, rsi
+7f5ecada9072  7F58              jg 0x7f5ecada90cc
+7f5ecada9074  0FB71417          movzx edx, word [rdi+rdx]
+7f5ecada9078  4881FA00500000    cmp rdx, 0x5000
+7f5ecada907f  744E              jz 0x7f5ecada90cf
+7f5ecada9081  EB49              jmp 0x7f5ecada90cc
+7f5ecada9083  4883FE38          cmp rsi, +0x38
+7f5ecada9087  7C43              jl 0x7f5ecada90cc
+7f5ecada9089  4881F886DD0000    cmp rax, 0xdd86
+7f5ecada9090  753A              jnz 0x7f5ecada90cc
+7f5ecada9092  0FB64714          movzx eax, byte [rdi+0x14]
+7f5ecada9096  4883F806          cmp rax, +0x06
+7f5ecada909a  7410              jz 0x7f5ecada90ac
+7f5ecada909c  4883F82C          cmp rax, +0x2c
+7f5ecada90a0  752A              jnz 0x7f5ecada90cc
+7f5ecada90a2  0FB64736          movzx eax, byte [rdi+0x36]
+7f5ecada90a6  4883F806          cmp rax, +0x06
+7f5ecada90aa  7520              jnz 0x7f5ecada90cc
+7f5ecada90ac  0FB74736          movzx eax, word [rdi+0x36]
+7f5ecada90b0  4881F800500000    cmp rax, 0x5000
+7f5ecada90b7  7416              jz 0x7f5ecada90cf
+7f5ecada90b9  4883FE3A          cmp rsi, +0x3a
+7f5ecada90bd  7C0D              jl 0x7f5ecada90cc
+7f5ecada90bf  0FB77738          movzx esi, word [rdi+0x38]
+7f5ecada90c3  4881FE00500000    cmp rsi, 0x5000
+7f5ecada90ca  7403              jz 0x7f5ecada90cf
+7f5ecada90cc  B000              mov al, 0x0
+7f5ecada90ce  C3                ret
+7f5ecada90cf  B001              mov al, 0x1
+7f5ecada90d1  C3                ret
 ```
 

--- a/tools/dump-markdown
+++ b/tools/dump-markdown
@@ -9,14 +9,18 @@ assert(filter, "usage: dump-markdown FILTER")
 
 function out(...) print(string.format(...)) end
 
+local function chomp(str)
+   return string.gsub(str, "\n$", "")
+end
+
 function compile(opts)
    local ok, result = pcall(pf.compile_filter, filter, opts)
    if not ok then result = 'Filter failed to compile: '..result end
-   return result
+   return chomp(result)
 end
 
 out("# %s\n\n", filter)
-out("## BPF\n\n```\n%s```\n\n",
+out("## BPF\n\n```\n%s\n```\n\n",
     compile({libpcap=true, source=true}))
 out("## BPF cross-compiled to Lua\n\n```\n%s\n```\n\n",
     compile({bpf=true, source=true}))


### PR DESCRIPTION
Fixes the markdown formatting in `doc/tcp-address.md`.