### PR TITLE
Fix undefined variable in pf.savefile

### DIFF
--- a/src/pf/savefile.lua
+++ b/src/pf/savefile.lua
@@ -36,6 +36,7 @@ function size(fd)
 end
 
 function open_and_mmap(filename)
+   local O_RDONLY = 0
    local fd = open(filename, O_RDONLY)
    if fd == -1 then
       error("Error opening " .. filename)


### PR DESCRIPTION
Fixes an undefined variable which isn't triggered unless the test is run in Snabb. e.g.,

```
$ ./snabb snsh -t pf
selftest: pf
../lib/pflua/src/pf/savefile.lua:39: variable 'O_RDONLY' is not declared
```